### PR TITLE
Update bootstrap file to use latest pip version.

### DIFF
--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -4,6 +4,7 @@ set -e
 
 # On RHL and Centos based linux, openssl needs to be set as Python Curl SSL library
 export PYCURL_SSL_LIBRARY=openssl
+pip3 install --upgrade pip
 pip3 install $PIP_OPTION --compile pycurl
 pip3 install $PIP_OPTION celery[sqs]
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Added line to `bootstrap.sh` to upgrade `pip` version to latest on Docker build. This resolves an issue where we could not install raw packages using the `pyproject.toml` format.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
