### PR TITLE
Adding new argument and functionality for running in 3 containers to …

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ COPY config/webserver_config.py ${AIRFLOW_USER_HOME}/webserver_config.py
 RUN chown -R airflow: ${AIRFLOW_USER_HOME}
 RUN chmod +x /entrypoint.sh
 
-EXPOSE 8080 5555 8793
+EXPOSE 8080 5555 8793 5732 6379
 
 USER airflow
 WORKDIR ${AIRFLOW_USER_HOME}

--- a/docker/config/airflow.cfg
+++ b/docker/config/airflow.cfg
@@ -26,7 +26,7 @@ executor = SequentialExecutor
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engine, more information
 # their website
-#sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/airflow.db
+#sql_alchemy_conn = db+postgres://airflow:airflow@postgres:5432/airflow
 
 # The encoding for the databases
 sql_engine_encoding = utf-8
@@ -603,8 +603,8 @@ worker_umask = 0o077
 
 # The Celery broker URL. Celery supports RabbitMQ, Redis and experimentally
 # a sqlalchemy database. Refer to the Celery documentation for more information.
-# broker_url = redis://redis:6379/0
-broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
+broker_url = redis://redis:6379/0
+#broker_url = sqla://airflow:airflow@localhost:3306/airflow
 
 
 # The Celery result_backend. When a job finishes, it needs to update the
@@ -613,8 +613,8 @@ broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 # This status is used by the scheduler to update the state of the task
 # The use of a database is highly recommended
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-result-backend-settings
-# result_backend = db+postgresql://postgres:airflow@postgres/airflow
-result_backend = db+mysql://airflow:airflow@localhost:3306/airflow
+ result_backend = db+postgresql://airflow:airflow@postgres:5432/airflow
+#result_backend = db+mysql://airflow:airflow@localhost:3306/airflow
 
 # Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
 # it ``airflow celery flower``. This defines the IP that Celery Flower runs on
@@ -640,7 +640,7 @@ default_queue = default
 sync_parallelism = 0
 
 # Import path for celery configuration options
-celery_config_options = celery_config.CUSTOM_CELERY_CONFIG
+celery_config_options = airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG
 ssl_active = False
 ssl_key =
 ssl_cert =

--- a/docker/docker-compose-multi.yml
+++ b/docker/docker-compose-multi.yml
@@ -1,0 +1,79 @@
+version: '3.7'
+services:
+  postgres:
+    image: postgres:10-alpine
+    environment:
+      - POSTGRES_USER=airflow
+      - POSTGRES_PASSWORD=airflow
+      - POSTGRES_DB=airflow
+    logging:
+      options:
+        max-size: 10m
+        max-file: "3"
+    volumes:
+      - "${PWD}/db-data:/var/lib/postgresql/data"
+
+  redis:
+    image: redis:5.0-alpine
+
+  local-webserver:
+    image: amazon/mwaa-local:2.0
+    restart: always
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      - LOAD_EX=n
+      - EXECUTOR=Celery
+    logging:
+      options:
+        max-size: 10m
+        max-file: "3"
+    volumes:
+      - ${PWD}/dags:/usr/local/airflow/dags
+      - ${PWD}/plugins:/usr/local/airflow/plugins
+      - ${PWD}/logs:/usr/local/airflow/logs
+    ports:
+      - "8080:8080"
+    command: local-webserver
+    healthcheck:
+      test: ["CMD-SHELL", "[ -f /usr/local/airflow/airflow-webserver.pid ]"]
+      interval: 30s
+      timeout: 30s
+      retries: 3
+
+  local-scheduler:
+    image: amazon/mwaa-local:2.0
+    restart: always
+    depends_on:
+      - local-webserver
+    environment:
+      - LOAD_EX=n
+      - EXECUTOR=Celery
+    logging:
+      options:
+        max-size: 10m
+        max-file: "3"
+    volumes:
+      - ${PWD}/dags:/usr/local/airflow/dags
+      - ${PWD}/plugins:/usr/local/airflow/plugins
+      - ${PWD}/logs:/usr/local/airflow/logs
+    command: local-scheduler
+
+  local-worker:
+    image: amazon/mwaa-local:2.0
+    restart: always
+    depends_on:
+      - local-scheduler
+    environment:
+      - LOAD_EX=n
+      - EXECUTOR=Celery
+    logging:
+      options:
+        max-size: 10m
+        max-file: "3"
+    volumes:
+      - ${PWD}/dags:/usr/local/airflow/dags
+      - ${PWD}/plugins:/usr/local/airflow/plugins
+      - ${PWD}/logs:/usr/local/airflow/logs
+    command: local-worker

--- a/docker/script/entrypoint.sh
+++ b/docker/script/entrypoint.sh
@@ -78,6 +78,26 @@ case "$1" in
     airflow users create -r Admin -u admin -e admin@example.com -f admin -l user -p test
     exec airflow webserver
     ;;
+  # Adding functionality to run in 3 Containers here to more align with MWAA environment
+  local-webserver)
+    install_requirements
+    airflow db init
+    airflow users create -r Admin -u admin -e admin@example.com -f admin -l user -p test
+    exec airflow webserver
+    ;;
+
+  local-scheduler)
+    install_requirements
+    airflow scheduler
+    ;;
+
+  local-worker)
+    install_requirements
+    AIRFLOW__CELERY__RESULT_BACKEND="db+postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}${POSTGRES_EXTRAS}"
+    export AIRFLOW__CELERY__RESULT_BACKEND
+    airflow celery worker
+    ;;
+
   resetdb)
     airflow db reset -y
     sleep 2

--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -16,6 +16,7 @@ display_help() {
    echo "start                  Start Airflow local environment. (LocalExecutor, Using postgres DB)"
    echo "test-requirements      Install requirements on an ephemeral instance of the container."
    echo "validate-prereqs       Validate pre-reqs installed (docker, docker-compose, python3, pip3)"
+   echo "start-celery           Start Airflow environment in 3 Containers with Celery Executor"
    echo
 }
 
@@ -75,6 +76,9 @@ reset-db)
    ;;
 start)
    docker-compose -f ./docker/docker-compose-local.yml up
+   ;;
+start-celery)
+   docker compose -f ./docker/docker-compose-multi.yml up
    ;;
 help)
    display_help


### PR DESCRIPTION
Adding the ability to run within 3 different containers which would be closer to how MWAA does the runtime. 

*Issue #, if available:*

*Description of changes:*
Added a new argument called start-celery for starting three containers and using the celery executor. 

Added a new docker compose file that adds three containers 1 each for the web server, scheduler and worker. 

Added required args to the entrypoint to allow having the three containers. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
