### PR TITLE
add start docker silently, down and stop docker command shortcut to m…

### DIFF
--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -14,6 +14,9 @@ display_help() {
    echo "build-image            Build Image Locally"
    echo "reset-db               Reset local PostgresDB container."
    echo "start                  Start Airflow local environment. (LocalExecutor, Using postgres DB)"
+   echo "start-silent           Start Airflow local environment as daemon. (LocalExecutor, Using postgres DB)"
+   echo "down                   Stop Airflow local environment. (LocalExecutor, Using postgres DB)"
+   echo "stop                   Shutdown Airflow local environment. (LocalExecutor, Using postgres DB)"
    echo "test-requirements      Install requirements on an ephemeral instance of the container."
    echo "validate-prereqs       Validate pre-reqs installed (docker, docker-compose, python3, pip3)"
    echo
@@ -75,6 +78,15 @@ reset-db)
    ;;
 start)
    docker-compose -f ./docker/docker-compose-local.yml up
+   ;;
+start-daemon)
+   docker-compose -f ./docker/docker-compose-local.yml up -d
+   ;;
+down)
+   docker-compose -f ./docker/docker-compose-local.yml down
+   ;;
+stop)
+   docker-compose -f ./docker/docker-compose-local.yml stop
    ;;
 help)
    display_help

--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -14,7 +14,7 @@ display_help() {
    echo "build-image            Build Image Locally"
    echo "reset-db               Reset local PostgresDB container."
    echo "start                  Start Airflow local environment. (LocalExecutor, Using postgres DB)"
-   echo "start-silent           Start Airflow local environment as daemon. (LocalExecutor, Using postgres DB)"
+   echo "start-daemon           Start Airflow local environment as daemon. (LocalExecutor, Using postgres DB)"
    echo "down                   Stop Airflow local environment. (LocalExecutor, Using postgres DB)"
    echo "stop                   Shutdown Airflow local environment. (LocalExecutor, Using postgres DB)"
    echo "test-requirements      Install requirements on an ephemeral instance of the container."


### PR DESCRIPTION
…waa-local-env

*Issue #, if available: None

*Description of changes: 
Adding shortcut to start Airflow docker silently as a daemon, docker down and docker stop. The shortcut docker down allow the docker to be suspended and can be start anytime without having to reload docker from scratch. User can continue where they left off. Stop allow the user to shutdown the docker completely.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
