### PR TITLE
build sqlite3 > 3.15.0 as needed by airflow cli

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ ARG PYTHON_DEPS=""
 ARG SYSTEM_DEPS=""
 ARG INDEX_URL=""
 ENV AIRFLOW_HOME=${AIRFLOW_USER_HOME}
+ENV LD_LIBRARY_PATH="/usr/local/lib"
 
 COPY script/bootstrap.sh /bootstrap.sh
 COPY script/systemlibs.sh /systemlibs.sh

--- a/docker/script/systemlibs.sh
+++ b/docker/script/systemlibs.sh
@@ -29,6 +29,32 @@ yum install -y nc
 # Needed for generating fernet key for local runner
 yum install -y python2-cryptography
 
+# build sqlite3 > 3.15.0 as needed by airflow cli
+# https://github.com/ferruzzi/airflow/blob/61c3020c0eca9599fc736d3fdecbdb049ddf6ff5/docs/apache-airflow/howto/set-up-database.rst
+yum -y install wget tar gzip gcc make expect
+
+wget https://www.sqlite.org/src/tarball/sqlite.tar.gz
+tar xzf sqlite.tar.gz
+cd sqlite/
+export CFLAGS="-DSQLITE_ENABLE_FTS3 \
+    -DSQLITE_ENABLE_FTS3_PARENTHESIS \
+    -DSQLITE_ENABLE_FTS4 \
+    -DSQLITE_ENABLE_FTS5 \
+    -DSQLITE_ENABLE_JSON1 \
+    -DSQLITE_ENABLE_LOAD_EXTENSION \
+    -DSQLITE_ENABLE_RTREE \
+    -DSQLITE_ENABLE_STAT4 \
+    -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT \
+    -DSQLITE_SOUNDEX \
+    -DSQLITE_TEMP_STORE=3 \
+    -DSQLITE_USE_URI \
+    -O2 \
+    -fPIC"
+export PREFIX="/usr/local"
+LIBS="-lm" ./configure --disable-tcl --enable-shared --enable-tempstore=always --prefix="$PREFIX"
+make
+make install
+
 # Install additional system library dependencies. Provided as a string of libraries separated by space
 if [ -n "${SYSTEM_DEPS}" ]; then yum install -y "${SYSTEM_DEPS}"; fi
 


### PR DESCRIPTION
Fixes #19 

airflow cli reports
`airflow.exceptions.AirflowConfigException: error: sqlite C library version too old (< 3.15.0).`

*Description of changes:*

By default the image contains Python 3.7.10 and sqlite 3.7.17
This change builds the latest sqlite version and updates LD_LIBRARY_PATH so that python3 uses the new libs

```
sh-4.2$ python3
Python 3.7.10 (default, Jun  3 2021, 00:02:01) 
[GCC 7.3.1 20180712 (Red Hat 7.3.1-13)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sqlite3
>>> sqlite3.sqlite_version
'3.37.0'

sh-4.2$ airflow version
2.1.0

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
