### PR TITLE
Updating ENV VARS with DB connection string

### DIFF
--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -21,6 +21,7 @@ services:
         environment:
             - LOAD_EX=n
             - EXECUTOR=Local
+            - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
         logging:
             options:
                 max-size: 10m


### PR DESCRIPTION
*Issue:*
When accessing the local `airflow` CLI within the Airflow container, the `AIRFLOW__CORE__SQL_ALCHEMY_CONN` environment variable is not set (nor is airflow.cfg) to use the Postgres database that is used for the web UI.

*Description of changes:*
Although there are probably better ways of doing this, I added the appropriate connection string to the `environment` section of docker-compose-local.yml to ensure that the airflow CLI will work in a shell session. 

```
environment:
            - LOAD_EX=n
            - EXECUTOR=Local
            - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Resolves #19 
