### PR TITLE
bugfix/v2.0.2 add constraint to install airflow v2.0.2

### DIFF
--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -14,7 +14,7 @@ services:
             - "${PWD}/db-data:/var/lib/postgresql/data"
 
     local-runner:
-        image: amazon/mwaa-local:2.0
+        image: amazon/mwaa-local:2.0.2
         restart: always
         depends_on:
             - postgres

--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -30,7 +30,7 @@ adduser -s /bin/bash -d "${AIRFLOW_USER_HOME}" airflow
 pip3 install $PIP_OPTION watchtower==1.0.1
 
 # Install default providers
-pip3 install apache-airflow-providers-amazon
+pip3 install --constraint /constraints.txt apache-airflow-providers-amazon
 
 # Use symbolic link to ensure Airflow 2.0's backport packages are in the same namespace as Airflow itself
 # see https://airflow.apache.org/docs/apache-airflow/stable/backport-providers.html#troubleshooting-installing-backport-packages

--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -10,6 +10,7 @@ pip3 install wheel
 
 # On RHL and Centos based linux, openssl needs to be set as Python Curl SSL library
 export PYCURL_SSL_LIBRARY=openssl
+pip3 install --upgrade pip
 pip3 install $PIP_OPTION --compile pycurl
 pip3 install $PIP_OPTION celery[sqs]
 

--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-AIRFLOW_VERSION=2.0
+AIRFLOW_VERSION=2.0.2
 
 display_help() {
    # Display Help
@@ -50,7 +50,7 @@ validate_prereqs() {
 }
 
 build_image() {
-   docker build --rm --compress -t amazon/mwaa-local:2.0 ./docker
+   docker build --rm --compress -t amazon/mwaa-local:$AIRFLOW_VERSION ./docker
 }
 
 case "$1" in


### PR DESCRIPTION
*Fixes Issue #22*

*Description of changes:*

bootstrap.sh line 34 `pip3 install apache-airflow-providers-amazon` was causing airflow v2.1.0 to be installed, overwriting v2.0.2

This change adds constraints.txt `pip3 install --constraint /constraints.txt apache-airflow-providers-amazon` so that the airflow version is properly constrained.

The build_image function also applies an updated tag `amazon/mwaa-local:2.0.2`

Building this commit will show the following version information in the airflow ui - as desired

```
Version: v2.0.2
Git Version:.release:2.0.2+e494306fb01f3a026e7e2832ca94902e96b526fa
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
