### PR TITLE
Add logic for persisting fernet key to airflow.cfg

### DIFF
--- a/docker/config/airflow.cfg
+++ b/docker/config/airflow.cfg
@@ -67,7 +67,7 @@ executor = SequentialExecutor
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engine, more information
 # their website
-# sql_alchemy_conn = sqlite:////tmp/airflow.db
+sql_alchemy_conn = postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
 
 # The encoding for the databases
 sql_engine_encoding = utf-8

--- a/docker/config/airflow.cfg
+++ b/docker/config/airflow.cfg
@@ -67,7 +67,7 @@ executor = SequentialExecutor
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engine, more information
 # their website
-sql_alchemy_conn = postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
+# sql_alchemy_conn = sqlite:////tmp/airflow.db
 
 # The encoding for the databases
 sql_engine_encoding = utf-8

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -21,6 +21,7 @@ services:
         environment:
             - LOAD_EX=n
             - EXECUTOR=Local
+            - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
         logging:
             options:
                 max-size: 10m

--- a/docker/script/entrypoint.sh
+++ b/docker/script/entrypoint.sh
@@ -90,7 +90,6 @@ case "$1" in
       sleep 2
     fi
     airflow create_user -r Admin -u admin -e admin@example.com -f admin -l user -p test
-    touch /usr/local/airflow/line83gotexecuted.txt
     exec airflow webserver
     ;;
   resetdb)


### PR DESCRIPTION
*Issue #27:*

*Description of changes:*

Added logic to entrypoint.sh to only generate the fernet key if it already hasn't been changed from `$FERNET_KEY` in airflow.cfg

```
#Add fernet key to airflow.cfg file:

if grep -q '$FERNET_KEY' /usr/local/airflow/airflow.cfg; then
    echo "fernet_key not set in airflow.cfg!"
    sed -i 's/$FERNET_KEY/TEMP_KEY/' /usr/local/airflow/airflow.cfg
    : "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY_GEN:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
    sed -i "s/TEMP_KEY/$AIRFLOW__CORE__FERNET_KEY/" /usr/local/airflow/airflow.cfg
    echo "fernet_key is now set in airflow.cfg"
  else
    echo "fernet_key is already set in airflow.cfg"
fi

```

I commented out the lines that set the variable in the beginning of entrypoint.sh and then set it to an environment variable since airflow.cfg will store this info.

After testing, this lets you add a variable with `airflow variable -s "Key1" "Value1"` within the an exec session on the container. In addition, these airflow variables can then be seen in the airflow UI. Likewise, a variable can be set in the UI and a user can see it in the CLI since both the CLI and the UI are using the same fernet key.

The changes in docker/docker-compose-local.yml were made so that I could use the airflow cli, these changes are already being fixed in #13 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
