### PR TITLE
Use ECR to avoid Docker Registry rate limits

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # DESCRIPTION: Amazon MWAA Local Dev Environment
 # BUILD: docker build --rm -t amazon/mwaa-local .
 
-FROM amazonlinux
+FROM public.ecr.aws/amazonlinux/amazonlinux
 LABEL maintainer="amazon"
 
 # Airflow


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Image build fails if the pull rate limit from Docker Registry is hit (100 pulls per six hours):

> 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit


Switching to ECR Public solves this, especially for AWS customers (https://aws.amazon.com/blogs/aws/amazon-ecr-public-a-new-public-container-registry/):

> Anyone who pulls images anonymously will get 500 GB of free data bandwidth each month. Simply authenticating with an AWS account increases free data bandwidth up to 5 TB each month when pulling images from the internet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
