### PR TITLE
Upgrade pip3 in bootstrap.sh

### DIFF
--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Upgrade pip version to latest
+python3 -m pip install --upgrade pip
+
 # On RHL and Centos based linux, openssl needs to be set as Python Curl SSL library
 export PYCURL_SSL_LIBRARY=openssl
 pip3 install $PIP_OPTION --compile pycurl


### PR DESCRIPTION
*Issue #, if available:*
Not applicable

*Description of changes:* 

Adding a command to bootstrap.sh to upgrade pip3.  This exists in the main branch, but wasn't backported to v1.10.12 branch.  Without pip3 upgrade, MWAA in AWS and mwaa-local-runner have different behaviors when testing requirements.txt with constraints locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
