### PR TITLE
docker-composev2-version-option

### DIFF
--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -27,7 +27,7 @@ validate_prereqs() {
       echo -e "Docker is Installed. \xE2\x9C\x94"
    fi
 
-   docker-compose -v >/dev/null 2>&1
+   docker-compose --version >/dev/null 2>&1
    if [ $? -ne 0 ]; then
       echo -e "'docker-compose' is not installed. \xE2\x9D\x8C"
    else


### PR DESCRIPTION
*Issue #, if available:*
Not applicable

*Description of changes:*
docker-compose v2 no longer supports the `-v` option. 

```
$ docker-compose -v
unknown shorthand flag: 'v' in -v
```

Changing this from `-v` to `--version` works in v1 and v2
```
$ docker-compose --version
Docker Compose version v2.0.0-rc.3
$ docker-compose disable-v2
$ docker-compose --version
docker-compose version 1.29.2, build 5becea4c
```
Note that while compose is in RC, this is the version that is deployed with the Docker Desktop 4.0.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
