### PR TITLE
Change in Docker-Airflow local executor's Volume

### DIFF
--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -26,8 +26,8 @@ services:
                 max-size: 10m
                 max-file: "3"
         volumes:
-            - ${PWD}/dags:/usr/local/airflow/dags
-            - ${PWD}/plugins:/usr/local/airflow/plugins
+            - "${PWD}/dags:/usr/local/airflow/dags"
+            - "${PWD}/plugins:/usr/local/airflow/plugins"
         ports:
             - "8080:8080"
         command: local-runner


### PR DESCRIPTION
The missing double quotes in local-runner's volume prevent users from accessing respective, virtual directories.

*Issue #, if available:*

*Description of changes:*
The missing double quotes in local-runner's volume prevent users from accessing respective, virtual directories.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
