### PR TITLE
fix: installs setuptools v57.x

### DIFF
--- a/docker/config/constraints.txt
+++ b/docker/config/constraints.txt
@@ -9,7 +9,7 @@ Flask-Caching==1.10.1
 Flask-JWT-Extended==3.25.1
 Flask-Login==0.4.1
 Flask-OAuthlib==0.9.5
-Flask-OpenID==1.2.5
+Flask-OpenID==1.3.0
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==0.14.3
 Flask==1.1.2

--- a/docker/config/constraints.txt
+++ b/docker/config/constraints.txt
@@ -9,7 +9,7 @@ Flask-Caching==1.10.1
 Flask-JWT-Extended==3.25.1
 Flask-Login==0.4.1
 Flask-OAuthlib==0.9.5
-Flask-OpenID==1.3.0
+Flask-OpenID==1.2.5
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==0.14.3
 Flask==1.1.2

--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -17,6 +17,9 @@ pip3 install $PIP_OPTION celery[sqs]
 # install postgres python client
 pip3 install $PIP_OPTION psycopg2
 
+# setuptools dropped support for use_2to3 in v58+ and psycopg2 will install the latest v59+ version
+pip3 install $PIP_OPTION "setuptools<=57.*"
+
 # install minimal Airflow packages
 pip3 install $PIP_OPTION --constraint /constraints.txt apache-airflow[crypto,celery,statsd"${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}"]=="${AIRFLOW_VERSION}"
 


### PR DESCRIPTION
this resolves issue #72 and allows the image to
be built locally

*Issue #, if available:*
#72 

*Description of changes:*
Installs `setuptools` v57.x allowing the image to be built locally with `./mwaa-local-env build-image`

*Tested with*
Ran `./mwaa-local-env build-image` and got a successfully built image that showed the UI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
