### PR TITLE
fix: updates `flask-openid` to 1.3.0

### DIFF
--- a/docker/config/constraints.txt
+++ b/docker/config/constraints.txt
@@ -9,7 +9,7 @@ Flask-Caching==1.10.1
 Flask-JWT-Extended==3.25.1
 Flask-Login==0.4.1
 Flask-OAuthlib==0.9.5
-Flask-OpenID==1.2.5
+Flask-OpenID==1.3.0
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==0.14.3
 Flask==1.1.2


### PR DESCRIPTION
this resolves issue #72 and allows the image to
be built locally

*Issue #, if available:*
#72 

*Description of changes:*
Updates `flask-openid` to 1.3.0 allowing the image to be built locally with `./mwaa-local-env build-image`

*Tested with*
Ran `./mwaa-local-env build-image` and got a successfully built image that showed the UI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.