### PR TITLE
Adding the AIRFLOW__CORE__SQL_ALCHEMY_CONN for local docker-compose

### DIFF
--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -21,6 +21,7 @@ services:
         environment:
             - LOAD_EX=n
             - EXECUTOR=Local
+            - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
         logging:
             options:
                 max-size: 10m


### PR DESCRIPTION


*Issue #, if available:*
Missing AIRFLOW__CORE__SQL_ALCHEMY_CONN variable in the local docker-compose resulting in SQLLITE outdated library errors.
Error:
airflow.exceptions.AirflowConfigException: error: sqlite C library version too old (< 3.15.0). See https://airflow.apache.org/docs/apache-airflow/2.0.2/howto/set-up-database.rst#setting-up-a-sqlite-database

*Description of changes:*
I have been trying to setup the MWAA local runner and been getting SQLITE outdated version errors. I later realized the AIRFLOW__CORE__SQL_ALCHEMY_CONN is not being passed into the docker container and somehow the mysql is being used which itself is not configured within the image properly. 

After making this change  in the docker-compose-local file (AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres:5432/airflow) i am able to continue with my mwaa setup without any issues. Could someone please review?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
