### PR TITLE
Add constraints argument to dags/requirements.txt

### DIFF
--- a/dags/requirements.txt
+++ b/dags/requirements.txt
@@ -1,0 +1,1 @@
+--constraints "https://raw.githubusercontent.com/apache/airflow/constraints-2.0.2/constraints-3.7.txt"


### PR DESCRIPTION
*Issue #, if available:* #67

*Description of changes:* Adds a constraints argument to the first line of dags/requirements.txt so that adding additional `apache-airflow-provider` requirements doesn't cause pip to automatically install their latest versions, which rely on higher versions of apache-airflow due to breaking changes and therefore cause pip to install the latest version of the whole `apache-airflow` package.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
