### PR TITLE
Add optional env file to set environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ docker/
     constraints.txt
     requirements.txt
     webserver_config.py
+    .env.localrunner
   script/
     bootstrap.sh
     entrypoint.sh
@@ -146,6 +147,7 @@ The following section contains common questions and answers you may encounter wh
 
 - You can setup the local Airflow's boto with the intended execution role to test your DAGs with AWS operators before uploading to your Amazon S3 bucket. To setup aws connection for Airflow locally see [Airflow | AWS Connection](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html)
 To learn more, see [Amazon MWAA Execution Role](https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-create-role.html).
+- You can set AWS credentials via environment variables set in the `docker/config/.env.localrunner` env file. To learn more about AWS environment variables, see [Environment variables to configure the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) and [Using temporary security credentials with the AWS CLI](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html#using-temp-creds-sdk-cli). Simply set the relevant environment variables in `.env.localrunner` and `./mwaa-local-env start`.
 
 ### How do I add libraries to requirements.txt and test install?
 

--- a/docker/config/.env.localrunner
+++ b/docker/config/.env.localrunner
@@ -1,0 +1,5 @@
+# Any environment variables set in this .env.localrunner file will be set in local-runner on start
+# Example environment variables using temporary security credentials
+#AWS_ACCESS_KEY_ID=XXXXXXXXXX
+#AWS_SECRET_ACCESS_KEY=YYYYYYYYYYYY
+#AWS_SESSION_TOKEN=ZZZZZZZZZZ

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -36,3 +36,5 @@ services:
             interval: 30s
             timeout: 30s
             retries: 3
+        env_file:
+            -   ./config/.env.localrunner


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added a env file called .env.local runner. Any environment variables set in this env file will be reflected in the local runner instance. Example use cases are using my AWS SSO temporary credentials to test boto3 and the ECSOperator locally. 

To reproduce/try, please use your AWS credentials or temporary AWS SSO credentials in the env file and ./mwaa-local-env start. Or simply set any environment variable in this env file and use the PythonOperator to print(os.environ['THE_VARIABLE_YOU_SET']).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
