### PR TITLE
Pass `-p $DOCKER_COMPOSE_PROJECT_NAME` (Project name) param

### DIFF
--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 AIRFLOW_VERSION=2.0.2
+DOCKER_COMPOSE_PROJECT_NAME=aws-mwaa-local-runner
 
 display_help() {
    # Display Help
@@ -71,10 +72,10 @@ build-image)
    build_image
    ;;
 reset-db)
-   docker-compose -f ./docker/docker-compose-resetdb.yml up
+   docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-resetdb.yml up
    ;;
 start)
-   docker-compose -f ./docker/docker-compose-local.yml up
+   docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-local.yml up
    ;;
 help)
    display_help

--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 AIRFLOW_VERSION=2.0.2
-DOCKER_COMPOSE_PROJECT_NAME=aws-mwaa-local-runner
+DOCKER_COMPOSE_PROJECT_NAME=aws-mwaa-local-runner-$AIRFLOW_VERSION
 
 display_help() {
    # Display Help


### PR DESCRIPTION
This passes `-p` parameter to docker-compose calls. 

*Description of changes:*

* Add `DOCKER_COMPOSE_PROJECT_NAME` variable and use it in `docker-compose` calls

This is for developer convenience, especially when running multiple docker projects in their locals.

The results of this change can be seen in the following screenshot. It makes it more explicit by naming the project name `aws-mwaa-local-runner` instead of simply `docker`

<img width="580" alt="Screen Shot 2022-02-20 at 12 54 40 PM" src="https://user-images.githubusercontent.com/299421/154857412-c5833716-5100-4629-b234-543fd4878ed0.png">

**Tests:**

1. Tested this by running `./mwaa-local-env start` in my local. This produced the results in the above screenshot
2. Tried testing with `./mwaa-local-env reset-db`.
    1. This produced an error, but I don't think the error is related to this and happens without this change
    2. This is captured as an issue in https://github.com/aws/aws-mwaa-local-runner/issues/100


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
