### PR TITLE
Apply setuptools version fix to v1.10.12 branch

### DIFF
--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -10,6 +10,9 @@ pip3 install $PIP_OPTION celery[sqs]
 # install postgres python client
 pip3 install $PIP_OPTION psycopg2
 
+# setuptools dropped support for use_2to3 in v58+ and psycopg2 will install the latest v59+ version
+pip3 install $PIP_OPTION "setuptools<=57.*"
+
 # install minimal Airflow packages
 pip3 install $PIP_OPTION --constraint /constraints.txt apache-airflow[crypto,celery,statsd"${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}"]=="${AIRFLOW_VERSION}"
 


### PR DESCRIPTION
As Airflow version v1.10.12 is still officially supported for MWAA, I think it would be good to ensure that the local runner for that version can still be built and used.
https://docs.aws.amazon.com/mwaa/latest/userguide/airflow-versions.html#airflow-versions-official
Currently, the build for this Airflow version fails with the error described in https://github.com/aws/aws-mwaa-local-runner/issues/72 too.

This PR applies the fix in https://github.com/aws/aws-mwaa-local-runner/pull/73 from @ivica-k to the branch for Airflow version v1.10.12.
Tested by successfully building the image for the v1.10.12 branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
