### PR TITLE
Support for the airflow upgrade_check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ virtual_python_plugin.py
 
 **Note**: this step assumes you have a DAG that corresponds to the custom plugin. For examples, see [MWAA Code Examples](https://docs.aws.amazon.com/mwaa/latest/userguide/sample-code.html).
 
+### Validating Airflow upgrade from 1.10 to 2.0
+
+You can use the "upgrade check" script - [apache-airflow-upgrade-check](https://pypi.org/project/apache-airflow-upgrade-check/) - to identify breaking changes as you plan migrating from 1.10.12 to 2.0. Run the command below.
+
+```bash
+./mwaa-local-env upgrade-check
+```
+
+
 ## What's next?
 
 - Learn how to upload the requirements.txt file to your Amazon S3 bucket in [Installing Python dependencies](https://docs.aws.amazon.com/mwaa/latest/userguide/working-dags-dependencies.html).

--- a/README.md
+++ b/README.md
@@ -134,12 +134,64 @@ virtual_python_plugin.py
 
 ### Validating Airflow upgrade from 1.10 to 2.0
 
-You can use the "upgrade check" script - [apache-airflow-upgrade-check](https://pypi.org/project/apache-airflow-upgrade-check/) - to identify breaking changes as you plan migrating from 1.10.12 to 2.0. Run the command below.
+You can use the "upgrade check" script - [apache-airflow-upgrade-check](https://pypi.org/project/apache-airflow-upgrade-check/) - to identify breaking changes as you plan migrating from 1.10.12 to 2.0. Copy your dags and plugins to the appropriate directories and run the command below.
 
 ```bash
 ./mwaa-local-env upgrade-check
 ```
 
+As an example the v1.10.12 [Amazon EMR job DAG](https://github.com/aws-samples/amazon-mwaa-examples/blob/main/dags/emr_job/1.10/emr_job.py) from the MWAA samples repository will generate the results bellow.
+
+```bash
+================================================================================================== STATUS ==================================================================================================
+
+Check for latest versions of apache-airflow and checker...........................................................................................................................................SUCCESS
+Remove airflow.AirflowMacroPlugin class...........................................................................................................................................................SUCCESS
+Ensure users are not using custom metaclasses in custom operators.................................................................................................................................SUCCESS
+Chain between DAG and operator not allowed........................................................................................................................................................SUCCESS
+Connection.conn_type is not nullable..............................................................................................................................................................SUCCESS
+Custom Executors now require full path............................................................................................................................................................SUCCESS
+Check versions of PostgreSQL, MySQL, and SQLite to ease upgrade to Airflow 2.0....................................................................................................................SUCCESS
+Hooks that run DB functions must inherit from DBApiHook...........................................................................................................................................SUCCESS
+Fernet is enabled by default......................................................................................................................................................................SUCCESS
+GCP service account key deprecation...............................................................................................................................................................SUCCESS
+Unify hostname_callable option in core section....................................................................................................................................................SUCCESS
+Changes in import paths of hooks, operators, sensors and others...................................................................................................................................FAIL
+Legacy UI is deprecated by default................................................................................................................................................................SUCCESS
+Logging configuration has been moved to new section...............................................................................................................................................FAIL
+Removal of Mesos Executor.........................................................................................................................................................................SUCCESS
+No additional argument allowed in BaseOperator....................................................................................................................................................SUCCESS
+/usr/local/lib/python3.7/site-packages/airflow/configuration.py:436: DeprecationWarning: The max_threads option in [scheduler] has been renamed to parsing_processes - the old setting has been used, but please update your config.
+  self.get(section, option, fallback=_UNSET)
+Rename max_threads to parsing_processes...........................................................................................................................................................SUCCESS
+Users must set a kubernetes.pod_template_file value...............................................................................................................................................SKIPPED
+Ensure Users Properly Import conf from Airflow....................................................................................................................................................SUCCESS
+SendGrid email uses old airflow.contrib module....................................................................................................................................................SUCCESS
+Check Spark JDBC Operator default connection name.................................................................................................................................................SUCCESS
+Changes in import path of remote task handlers....................................................................................................................................................SUCCESS
+Connection.conn_id is not unique..................................................................................................................................................................SUCCESS
+Use CustomSQLAInterface instead of SQLAInterface for custom data models...........................................................................................................................SUCCESS
+Found 7 problems.
+```
+
+The recommendation section details how exactly to address the failures.
+
+```bash
+============================================================================================= RECOMMENDATIONS ==============================================================================================
+
+Changes in import paths of hooks, operators, sensors and others
+---------------------------------------------------------------
+Many hooks, operators and other classes has been renamed and moved. Those changes were part of unifying names and imports paths as described in AIP-21.
+The `contrib` folder has been replaced by `providers` directory and packages:
+https://github.com/apache/airflow#backport-packages
+
+Problems:
+
+  1.  Please install `apache-airflow-backport-providers-amazon`
+  2.  Using `airflow.contrib.operators.emr_add_steps_operator.EmrAddStepsOperator` should be replaced by `airflow.providers.amazon.aws.operators.emr_add_steps.EmrAddStepsOperator`. Affected file: /usr/local/airflow/dags/emr_job.py
+  3.  Using `airflow.contrib.operators.emr_create_job_flow_operator.EmrCreateJobFlowOperator` should be replaced by `airflow.providers.amazon.aws.operators.emr_create_job_flow.EmrCreateJobFlowOperator`. Affected file: /usr/local/airflow/dags/emr_job.py
+  4.  Using `airflow.contrib.sensors.emr_step_sensor.EmrStepSensor` should be replaced by `airflow.providers.amazon.aws.sensors.emr_step.EmrStepSensor`. Affected file: /usr/local/airflow/dags/emr_job.py
+```
 
 ## What's next?
 

--- a/docker/config/constraints.txt
+++ b/docker/config/constraints.txt
@@ -8,7 +8,7 @@ Flask-Bcrypt==0.7.1
 Flask-Caching==1.3.3
 Flask-JWT-Extended==3.25.0
 Flask-Login==0.4.1
-Flask-OpenID==1.2.5
+Flask-OpenID==1.3.0
 Flask-SQLAlchemy==2.4.4
 Flask-WTF==0.14.3
 Flask==1.1.2

--- a/docker/config/requirements.txt
+++ b/docker/config/requirements.txt
@@ -33,7 +33,7 @@ Flask-Babel==1.0.0
 Flask-Caching==1.3.3
 Flask-JWT-Extended==3.24.1
 Flask-Login==0.4.1
-Flask-OpenID==1.2.5
+Flask-OpenID==1.3.0
 Flask-SQLAlchemy==2.4.4
 flask-swagger==0.2.14
 Flask-WTF==0.14.3

--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -22,6 +22,9 @@ adduser -s /bin/bash -d "${AIRFLOW_USER_HOME}" airflow
 # install watchtower for Cloudwatch logging
 pip3 install $PIP_OPTION watchtower==1.0.1
 
+# install upgrade check script
+pip3 install apache-airflow-upgrade-check==1.4.0
+
 # Use symbolic link to ensure Airflow 2.0's backport packages are in the same namespace as Airflow itself
 # see https://airflow.apache.org/docs/apache-airflow/stable/backport-providers.html#troubleshooting-installing-backport-packages
 ln -s /usr/local/airflow/.local/lib/python3.7/site-packages/airflow/providers /usr/local/lib/python3.7/site-packages/airflow/providers

--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -16,6 +16,7 @@ display_help() {
    echo "start                  Start Airflow local environment. (LocalExecutor, Using postgres DB)"
    echo "test-requirements      Install requirements on an ephemeral instance of the container."
    echo "validate-prereqs       Validate pre-reqs installed (docker, docker-compose, python3, pip3)"
+   echo "upgrade-check          Check for breaking changes when updating from Airflow 1.10 to 2.0"
    echo
 }
 
@@ -66,6 +67,9 @@ test-requirements)
      build_image
    fi
    docker run -v $(pwd)/dags:/usr/local/airflow/dags -it amazon/mwaa-local:$AIRFLOW_VERSION test-requirements
+   ;;
+upgrade-check)
+   COMPOSE_FILE=./docker/docker-compose-local.yml docker-compose run --rm local-runner airflow upgrade_check
    ;;
 build-image)
    build_image


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

Added support for the `airflow upgrade_check` script to validate migrations from 1.10 to 2.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
