### PR TITLE
Mount plugins directory when testing requirements

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # DESCRIPTION: Amazon MWAA Local Dev Environment
 # BUILD: docker build --rm -t amazon/mwaa-local .
 
-FROM amazonlinux
+FROM public.ecr.aws/amazonlinux/amazonlinux
 LABEL maintainer="amazon"
 
 # Airflow

--- a/docker/config/requirements.txt
+++ b/docker/config/requirements.txt
@@ -36,7 +36,7 @@ dnspython==1.16.0
 docutils==0.16
 email-validator==1.1.2
 Flask==1.1.2
-Flask-AppBuilder==3.2.3
+Flask-AppBuilder==3.3.0
 Flask-Babel==1.0.0
 Flask-Caching==1.10.1
 Flask-JWT-Extended==3.25.1

--- a/docker/config/requirements.txt
+++ b/docker/config/requirements.txt
@@ -11,7 +11,7 @@ apache-airflow-providers-sqlite==1.0.2
 apispec==3.3.2
 argcomplete==1.12.3
 attrs==20.3.0
-Babel==2.9.0
+babel==2.9.1
 billiard==3.6.4.0
 blinker==1.4
 boto3==1.17.53

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -14,7 +14,7 @@ services:
             - "${PWD}/db-data:/var/lib/postgresql/data"
 
     local-runner:
-        image: amazon/mwaa-local:2.0
+        image: amazon/mwaa-local:2.0.2
         restart: always
         depends_on:
             - postgres

--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -29,6 +29,15 @@ adduser -s /bin/bash -d "${AIRFLOW_USER_HOME}" airflow
 # install watchtower for Cloudwatch logging
 pip3 install $PIP_OPTION watchtower==1.0.1
 
+pip3 install $PIP_OPTION apache-airflow-providers-tableau==1.0.0
+pip3 install $PIP_OPTION apache-airflow-providers-databricks==1.0.1
+pip3 install $PIP_OPTION apache-airflow-providers-ssh==1.3.0
+pip3 install $PIP_OPTION apache-airflow-providers-postgres==1.0.2
+pip3 install $PIP_OPTION apache-airflow-providers-docker==1.2.0
+pip3 install $PIP_OPTION apache-airflow-providers-oracle==1.1.0
+pip3 install $PIP_OPTION apache-airflow-providers-presto==1.0.2
+pip3 install $PIP_OPTION apache-airflow-providers-sftp==1.2.0
+
 # Install default providers
 pip3 install --constraint /constraints.txt apache-airflow-providers-amazon
 

--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -17,6 +17,9 @@ pip3 install $PIP_OPTION celery[sqs]
 # install postgres python client
 pip3 install $PIP_OPTION psycopg2
 
+# setuptools dropped support for use_2to3 in v58+ and psycopg2 will install the latest v59+ version
+pip3 install $PIP_OPTION "setuptools<=57.*"
+
 # install minimal Airflow packages
 pip3 install $PIP_OPTION --constraint /constraints.txt apache-airflow[crypto,celery,statsd"${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}"]=="${AIRFLOW_VERSION}"
 

--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -30,7 +30,7 @@ adduser -s /bin/bash -d "${AIRFLOW_USER_HOME}" airflow
 pip3 install $PIP_OPTION watchtower==1.0.1
 
 # Install default providers
-pip3 install apache-airflow-providers-amazon
+pip3 install --constraint /constraints.txt apache-airflow-providers-amazon
 
 # Use symbolic link to ensure Airflow 2.0's backport packages are in the same namespace as Airflow itself
 # see https://airflow.apache.org/docs/apache-airflow/stable/backport-providers.html#troubleshooting-installing-backport-packages

--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -10,6 +10,7 @@ pip3 install wheel
 
 # On RHL and Centos based linux, openssl needs to be set as Python Curl SSL library
 export PYCURL_SSL_LIBRARY=openssl
+pip3 install --upgrade pip
 pip3 install $PIP_OPTION --compile pycurl
 pip3 install $PIP_OPTION celery[sqs]
 

--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-AIRFLOW_VERSION=2.0
+AIRFLOW_VERSION=2.0.2
 
 display_help() {
    # Display Help
@@ -50,7 +50,7 @@ validate_prereqs() {
 }
 
 build_image() {
-   docker build --rm --compress -t amazon/mwaa-local:2.0 ./docker
+   docker build --rm --compress -t amazon/mwaa-local:$AIRFLOW_VERSION ./docker
 }
 
 case "$1" in

--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -65,7 +65,7 @@ test-requirements)
      echo "Container amazon/mwaa-local:$AIRFLOW_VERSION not built. Building locally."
      build_image
    fi
-   docker run -v $(pwd)/dags:/usr/local/airflow/dags -it amazon/mwaa-local:$AIRFLOW_VERSION test-requirements
+   docker run -v $(pwd)/dags:/usr/local/airflow/dags -v $(pwd)/plugins:/usr/local/airflow/plugins -it amazon/mwaa-local:$AIRFLOW_VERSION test-requirements
    ;;
 build-image)
    build_image


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The test-requirements command only mounts the dags directory. According to AWS documentation (option 2) https://docs.aws.amazon.com/mwaa/latest/userguide/best-practices-dependencies.html#best-practices-dependencies-python-wheels, MWAA supports .whl dependencies in the plugins directory. Without mounting this, we cannot fully test our requirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
