### PR TITLE
Produce only one Fernet key per image, instead of per container

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ docker/
   script/
     bootstrap.sh
     entrypoint.sh
+    systemlibs.sh
+    generate_key.sh
   docker-compose-dbonly.yml
   docker-compose-local.yml
   docker-compose-sequential.yml
@@ -159,13 +161,20 @@ To learn more, see [Amazon MWAA Execution Role](https://docs.aws.amazon.com/mwaa
 
 The following section contains errors you may encounter when using the Docker container image in this repository.
 
-## My environment is not starting - process failed with dag_stats_table already exists
+### My environment is not starting - process failed with dag_stats_table already exists
 
 - If you encountered [the following error](https://issues.apache.org/jira/browse/AIRFLOW-3678): `process fails with "dag_stats_table already exists"`, you'll need to reset your database using the following command:
 
 ```bash
 ./mwaa-local-env reset-db
 ```
+
+### Fernet Key InvalidToken
+
+A Fernet Key is generated during image build (`./mwaa-local-env build-image`) and is durable throughout all
+containers started from that image. This key is used to [encrypt connection passwords in the Airflow DB](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/fernet.html).
+If changes are made to the image and it is rebuilt, you may get a new key that will not match the key used when
+the Airflow DB was initialized, in this case you will need to reset the DB (`./mwaa-local-env reset-db`).
 
 ## Security
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,11 +17,13 @@ ENV AIRFLOW_HOME=${AIRFLOW_USER_HOME}
 
 COPY script/bootstrap.sh /bootstrap.sh
 COPY script/systemlibs.sh /systemlibs.sh
+COPY script/generate_key.sh /generate_key.sh
 COPY config/constraints.txt /constraints.txt
 COPY config/requirements.txt /requirements.txt
 
 RUN chmod u+x /systemlibs.sh && /systemlibs.sh
 RUN chmod u+x /bootstrap.sh && /bootstrap.sh
+RUN chmod u+x /generate_key.sh && /generate_key.sh
 
 # Post bootstrap to avoid expensive docker rebuilds
 COPY script/entrypoint.sh /entrypoint.sh

--- a/docker/script/entrypoint.sh
+++ b/docker/script/entrypoint.sh
@@ -4,7 +4,7 @@ TRY_LOOP="20"
 
 # Global defaults
 : "${AIRFLOW_HOME:="/usr/local/airflow"}"
-: "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
+: "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY:=$(cat /usr/local/etc/airflow_fernet_key)}}"
 : "${AIRFLOW__CORE__EXECUTOR:=${EXECUTOR:-Sequential}Executor}"
 
 # Load DAGs examples (default: Yes)

--- a/docker/script/generate_key.sh
+++ b/docker/script/generate_key.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Generate fernet key
+FERNET_KEY="$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")"
+
+# Store it in the image so that it can be used in entrypoint
+echo "$FERNET_KEY" > /usr/local/etc/airflow_fernet_key


### PR DESCRIPTION
Fernet is used to encrypt passwords in Connections, if the Fernet key is
different between executions of the local runner (where a new container
is created) the key used to encrypt the keys will be different than the
key used to decrypt. This commit creates one key during image build and
is re-used by all containers until rebuild.

fixes #27
fixes #24
closes #28

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
