### PR TITLE
Fix image tag in sequential compose file

### DIFF
--- a/docker/docker-compose-sequential.yml
+++ b/docker/docker-compose-sequential.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
     webserver:
-        image: amazon/mwaa-local:2.0
+        image: amazon/mwaa-local:2.0.2
         restart: always
         environment:
             - LOAD_EX=n

--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -72,7 +72,7 @@ build-image)
    build_image
    ;;
 reset-db)
-   docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-resetdb.yml up
+   docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-resetdb.yml up --abort-on-container-exit
    ;;
 start)
    docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-local.yml up


### PR DESCRIPTION
- patch docker-compose-sequential image tag, similar to #102
- Also add --abort-on-container-exit to reset-db command so that
  once the db reset is complete the command does not hang waiting
  for the postgres container to stop (which it never will without
  manual intervention, e.g. ctrl+C)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
