### PR TITLE
[Airflow v2.2.2] Add a GH action for building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,12 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: ./mwaa-local-env build-image


### PR DESCRIPTION
# Description

Adding a GitHub action to automatically build the image on `push` and `pull_request` events. This way the reviewers can validate that a PR is not going to break the build before merging it.

# Testing

See [this](https://github.com/rafidka/aws-mwaa-local-runner/runs/6236143399?check_suite_focus=true) for the latest build on v2.2.2 branch in my fork.

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
