### PR TITLE
Secure cookie fix 222

### DIFF
--- a/docker/config/airflow.cfg
+++ b/docker/config/airflow.cfg
@@ -509,7 +509,7 @@ navbar_color = #fff
 default_dag_run_display_number = 25
 
 # Set secure flag on session cookie
-cookie_secure = True
+cookie_secure = False
 
 # Set samesite policy on session cookie
 cookie_samesite = Lax


### PR DESCRIPTION
*Issue #, if available:*
#140 
#10 

*Description of changes:*
Sets cookie_secure = False in airflow.cfg so that SQLAlchemy session cookie may be set on HTTP connection.  Note that you may need to delete existing cookies for this to work correctly.

