### PR TITLE
update dagbag_import_timeout default

### DIFF
--- a/docker/config/airflow.cfg
+++ b/docker/config/airflow.cfg
@@ -126,7 +126,7 @@ fernet_key = $FERNET_KEY
 donot_pickle = False
 
 # How long before timing out a python file import
-dagbag_import_timeout = 30.0
+dagbag_import_timeout = 30
 
 # Should a traceback be shown in the UI for dagbag import errors,
 # instead of just the exception message


### PR DESCRIPTION
change dagbag_import_timeout = 30 (int) from 30.0 (float)

*Issue #, if available:*

https://github.com/aws/aws-mwaa-local-runner/issues/46

*Description of changes:*

change dagbag_import_timeout default to 30 from 30.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
