### PR TITLE
Increase yum timeout

### DIFF
--- a/docker/script/systemlibs.sh
+++ b/docker/script/systemlibs.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
 set -e
+
+# increase timeout to address build issues referenced in
+# https://github.com/aws/aws-mwaa-local-runner/issues/7
+# https://github.com/aws/aws-mwaa-local-runner/issues/141
+sed -i "s/timeout=5/timeout=10/g" /etc/yum.conf
+
 yum update -y
 
 # install basic python environment


### PR DESCRIPTION
*Issue #:*
#7 and #141


*Description of changes:*

The server hosting the mirrorlist is slow to respond. 

When running `yum` in https://github.com/aws/aws-mwaa-local-runner/blob/v2.2.2/docker/script/systemlibs.sh#L4 we hit the default timeout of 5 seconds.

This PR increases the default timeout by editing `/etc/yum.conf` before running the `yum` commands.
