### PR TITLE
Fix apache-airflow-providers-amazon version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,4 @@
 --constraint "/usr/local/airflow/dags/constraints-3.7-amazon-6.0.txt"
 
 apache-airflow-providers-amazon==6.0.0
+apache-airflow-providers-amazon==2.4.0


### PR DESCRIPTION
*Description of changes:*
According to the rquirements file in `docker/config/requirements.txt`, the version of the apache-airflow-providers-amazon should be 2.4.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
