### PR TITLE
adding --platform linux/amd64 flag for the docker build when hardware…

### DIFF
--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -56,6 +56,7 @@ build_image() {
       docker build --rm --compress -t amazon/mwaa-local:$AIRFLOW_VERSION ./docker --platform linux/amd64
    else
       docker build --rm --compress -t amazon/mwaa-local:$AIRFLOW_VERSION ./docker
+   fi
 }
 
 case "$1" in

--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -52,7 +52,10 @@ validate_prereqs() {
 }
 
 build_image() {
-   docker build --rm --compress -t amazon/mwaa-local:$AIRFLOW_VERSION ./docker
+   if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+      docker build --rm --compress -t amazon/mwaa-local:$AIRFLOW_VERSION ./docker --platform linux/amd64
+   else
+      docker build --rm --compress -t amazon/mwaa-local:$AIRFLOW_VERSION ./docker
 }
 
 case "$1" in


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-mwaa-local-runner/issues/214 - people with M1 Macs are unable to build the container due to failed dependencies

*Description of changes:*
adding --platform linux/amd64 flag for the docker build command when  the hardware platform name is either arm64 or aarch64

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
