### PR TITLE
fixes for Apple Silicon

### DIFF
--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -15,7 +15,6 @@ services:
 
     local-runner:
         image: amazon/mwaa-local:2_4
-        platform: "linux/amd64"
         restart: always
         depends_on:
             - postgres

--- a/docker/docker-compose-resetdb.yml
+++ b/docker/docker-compose-resetdb.yml
@@ -15,7 +15,6 @@ services:
 
     resetdb:
         image: amazon/mwaa-local:2_4
-        platform: "linux/amd64"
         depends_on:
             - postgres
         environment:

--- a/docker/docker-compose-sequential.yml
+++ b/docker/docker-compose-sequential.yml
@@ -2,7 +2,6 @@ version: '3.7'
 services:
     webserver:
         image: amazon/mwaa-local:2_4
-        platform: "linux/amd64"
         restart: always
         environment:
             - LOAD_EX=n

--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -48,10 +48,18 @@ yum install -y java-1.8.0-openjdk
 # so a newer version of the dependency must be installed from source.
 sudo mkdir mariadb_rpm
 sudo chown airflow /mariadb_rpm
-wget https://dlm.mariadb.com/2596575/MariaDB/mariadb-10.8.6/yum/rhel7-amd64/rpms/MariaDB-common-10.8.6-1.el7.centos.x86_64.rpm -P /mariadb_rpm
-wget https://dlm.mariadb.com/2596577/MariaDB/mariadb-10.8.6/yum/rhel7-amd64/rpms/MariaDB-compat-10.8.6-1.el7.centos.x86_64.rpm -P /mariadb_rpm
-wget https://dlm.mariadb.com/2596582/MariaDB/mariadb-10.8.6/yum/rhel7-amd64/rpms/MariaDB-shared-10.8.6-1.el7.centos.x86_64.rpm -P /mariadb_rpm
-wget https://dlm.mariadb.com/2596593/MariaDB/mariadb-10.8.6/yum/rhel7-amd64/rpms/MariaDB-devel-10.8.6-1.el7.centos.x86_64.rpm -P /mariadb_rpm
+
+if [[ $(uname -p) == "aarch64" ]]; then
+	wget https://dlm.mariadb.com/2592621/MariaDB/mariadb-10.8.6/yum/rhel7-aarch64/rpms/MariaDB-common-10.8.4-1.el7.centos.aarch64.rpm -P /mariadb_rpm
+	wget https://dlm.mariadb.com/2592615/MariaDB/mariadb-10.8.6/yum/rhel7-aarch64/rpms/MariaDB-compat-10.8.4-1.el7.centos.aarch64.rpm -P /mariadb_rpm
+	wget https://dlm.mariadb.com/2592630/MariaDB/mariadb-10.8.6/yum/rhel7-aarch64/rpms/MariaDB-shared-10.8.4-1.el7.centos.aarch64.rpm -P /mariadb_rpm
+	wget https://dlm.mariadb.com/2592622/MariaDB/mariadb-10.8.6/yum/rhel7-aarch64/rpms/MariaDB-devel-10.8.4-1.el7.centos.aarch64.rpm -P /mariadb_rpm
+else
+	wget https://dlm.mariadb.com/2596575/MariaDB/mariadb-10.8.6/yum/rhel7-amd64/rpms/MariaDB-common-10.8.6-1.el7.centos.x86_64.rpm -P /mariadb_rpm
+	wget https://dlm.mariadb.com/2596577/MariaDB/mariadb-10.8.6/yum/rhel7-amd64/rpms/MariaDB-compat-10.8.6-1.el7.centos.x86_64.rpm -P /mariadb_rpm
+	wget https://dlm.mariadb.com/2596582/MariaDB/mariadb-10.8.6/yum/rhel7-amd64/rpms/MariaDB-shared-10.8.6-1.el7.centos.x86_64.rpm -P /mariadb_rpm
+	wget https://dlm.mariadb.com/2596593/MariaDB/mariadb-10.8.6/yum/rhel7-amd64/rpms/MariaDB-devel-10.8.6-1.el7.centos.x86_64.rpm -P /mariadb_rpm
+fi
 
 # install mariadb_devel and its dependencies
 sudo rpm -ivh /mariadb_rpm/*


### PR DESCRIPTION
* add a check on architecture to pull the right RPMs from mariaDB (somehow the RPMs listed under `10.8.6` are named `10.8.4` for aarch64 ??? Couldn't find `10.8.6` for aarch64 🤷)
* remove platform in docker compose since default seems to resolve to the right platform anyway ?

Based on an original idea by @johnnypez, who commented on the issue.

* Issue : https://github.com/aws/aws-mwaa-local-runner/issues/211