### PR TITLE
sqlite C library version too old (< 3.15.0)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # DESCRIPTION: Amazon MWAA Local Dev Environment
 # BUILD: docker build --rm -t amazon/mwaa-local .
 
-FROM amazonlinux:2
+FROM amazonlinux:2.0.20230307.0
 LABEL maintainer="amazon"
 
 # Airflow
@@ -39,6 +39,15 @@ COPY config/webserver_config.py ${AIRFLOW_USER_HOME}/webserver_config.py
 
 RUN chown -R airflow: ${AIRFLOW_USER_HOME}
 RUN chmod +x /entrypoint.sh
+
+RUN wget https://sqlite.org/2023/sqlite-autoconf-3410100.tar.gz
+RUN tar -xvf sqlite-autoconf-3410100.tar.gz
+WORKDIR sqlite-autoconf-3410100
+RUN ./configure
+RUN make clean && make -j 20 && make install
+WORKDIR ..
+ENV LD_LIBRARY_PATH="/usr/local/lib"
+RUN source /etc/profile
 
 EXPOSE 8080 5555 8793
 


### PR DESCRIPTION
*Issue #, if available:*

```
airflow db check

sqlite C library version too old (< 3.15.0)
```

*Description of changes:*

Get the newer sqlite version (3.41.1), build and install it

After that

```
airflow db check

...
[2023-03-21 08:31:08,263] {{db.py:1727}} INFO - Connection successful.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
