### PR TITLE
Remove restart config from local-runner service

### DIFF
--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -15,7 +15,6 @@ services:
 
     local-runner:
         image: amazon/mwaa-local:2_5
-        restart: always
         depends_on:
             - postgres
         environment:


### PR DESCRIPTION
## Background

The inconsistent [restart](https://docs.docker.com/compose/compose-file/compose-file-v3/#restart) behavior on the `local-runner` service vs. the `postgres` service in the `docker-compose` files means the airflow instance can start without its required metadata DB, which can make for a confusing local dev experience.

This PR makes the restart behavior identical across the two services - I think neither should restart - but could go either way here. If the maintainers would prefer _both_ restart I think that'd be fine. 

## Repro steps

0. Open Docker
1. `./mwaa-local-env build-image` - build the image
2. `./mwaa-local-env start` - start the instance, let it provision its DB
3. Stop both services
4. Close docker
5. Reboot, re-open docker, do anything that would trigger a container restart per its restart config (I'm not sure what all the permutations here are)
6. Inspect running containers, note that the local-runner (Airflow) container is running, but its metadata database isn't.
7. Inspect the logs for the running `local-runner` container, note it's full of `waiting for Postgres...` entries

## Expected behavior

Both containers are necessary, so they should either both restart, or neither should.

## CLA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
