### PR TITLE
Respect constraints when instaling base provider requirements

### DIFF
--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -91,7 +91,7 @@ if [ -n "${PYTHON_DEPS}" ]; then sudo -u airflow pip3 install $PIP_OPTION "${PYT
 
 MWAA_BASE_PROVIDERS_FILE=/mwaa-base-providers-requirements.txt
 echo "Installing providers supported for airflow version ${AIRFLOW_VERSION}"
-sudo -u airflow pip3 install $PIP_OPTION -r $MWAA_BASE_PROVIDERS_FILE
+sudo -u airflow pip3 install --constraint /constraints.txt $PIP_OPTION -r $MWAA_BASE_PROVIDERS_FILE
 
 # jq is used to parse json
 yum install -y jq


### PR DESCRIPTION
*Issue #, if available:* 
#282

*Description of changes:*
Added constraints when installing MWAA base provider packages, so that the installation respects these constraints and doesn't attempt to install incompatible versions, such as `lxml==4.9.3`

*Testing:*
Verified that the image builds correctly, and that conflicts arise when attempting to install `lxml==4.9.3`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
