### PR TITLE
v2.4.3: respect constraints when instaling base provider requirements

### DIFF
--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -91,7 +91,7 @@ if [ -n "${PYTHON_DEPS}" ]; then sudo -u airflow pip3 install $PIP_OPTION "${PYT
 
 MWAA_BASE_PROVIDERS_FILE=/mwaa-base-providers-requirements.txt
 echo "Installing providers supported for airflow version ${AIRFLOW_VERSION}"
-sudo -u airflow pip3 install $PIP_OPTION -r $MWAA_BASE_PROVIDERS_FILE
+sudo -u airflow pip3 install --constraint /constraints.txt $PIP_OPTION -r $MWAA_BASE_PROVIDERS_FILE
 
 # jq is used to parse json
 yum install -y jq


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-mwaa-local-runner/issues/282

*Description of changes:*
Cherry-pick of the commit that fixes the issue on branch v2.5.1, see https://github.com/aws/aws-mwaa-local-runner/pull/289.

Tested locally by building the image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
