### PR TITLE
Remove quotes from default password

### DIFF
--- a/docker/config/.env.localrunner
+++ b/docker/config/.env.localrunner
@@ -5,7 +5,7 @@
 # AWS_SESSION_TOKEN=ZZZZZZZZZZ 
 
 # to change default password you'll need to delete the db-data folder (when running locally)
-DEFAULT_PASSWORD="test"
+DEFAULT_PASSWORD=test
 S3_DAGS_PATH=""
 S3_PLUGINS_PATH=""
 S3_REQUIREMENTS_PATH=""


### PR DESCRIPTION
Fixes #210, #300

Changes the dotenv file to remove quotes from the `DEFAULT_PASSWORD` value, which allows the password `test` to be used, rather than `"test"`. This has been checked on v2.6.3 but could be retrospectively applied to previous versions if possible (issue #210 was raised regarding v2.4.3)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
