### PR TITLE
fix: adjust docker compose cmd for v1 and v2

### DIFF
--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -3,6 +3,13 @@
 AIRFLOW_VERSION=2_6
 DOCKER_COMPOSE_PROJECT_NAME=aws-mwaa-local-runner-$AIRFLOW_VERSION
 
+# Check if using docker compose v1 or v2
+if command -v docker-compose &> /dev/null; then
+  DOCKER_COMPOSE=docker-compose
+else
+  DOCKER_COMPOSE="docker compose"
+fi
+
 display_help() {
    # Display Help
    echo "======================================"
@@ -30,7 +37,7 @@ validate_prereqs() {
       echo -e "Docker is Installed. \xE2\x9C\x94"
    fi
 
-   docker-compose -v >/dev/null 2>&1
+   $DOCKER_COMPOSE -v >/dev/null 2>&1
    if [ $? -ne 0 ]; then
       echo -e "'docker-compose' is not installed. \xE2\x9D\x8C"
    else
@@ -94,10 +101,10 @@ build-image)
    build_image
    ;;
 reset-db)
-   docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-resetdb.yml up --abort-on-container-exit
+   $DOCKER_COMPOSE -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-resetdb.yml up --abort-on-container-exit
    ;;
 start)
-   docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-local.yml up
+   $DOCKER_COMPOSE -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-local.yml up
    ;;
 help)
    display_help


### PR DESCRIPTION
*Issue #, if available:*

Running `./mwaa-local-env` fails when you have docker compose v2 installed.

*Description of changes:*

Docker compose's cli command for v2 is "docker compose". Adjust the bash script to detect which is installed and use that.

https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
