### PR TITLE
feat(mwaa-local-env): adding in --remove-orphans to docker-compose co…

### DIFF
--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -94,10 +94,10 @@ build-image)
    build_image
    ;;
 reset-db)
-   docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-resetdb.yml up --abort-on-container-exit
+   docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-resetdb.yml up --remove-orphans --abort-on-container-exit
    ;;
 start)
-   docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-local.yml up
+   docker-compose -p $DOCKER_COMPOSE_PROJECT_NAME -f ./docker/docker-compose-local.yml up --remove-orphans
    ;;
 help)
    display_help


### PR DESCRIPTION
…mmands.

*Description of changes:* Adding in the `remove-orphans` command which is useful when experimenting with various changes such as adding and removing containers. from the docs `Remove containers for services not defined in the Compose file.` So if you're experimenting with adding and removing things you end up with dangling containers that eat up space if you don't add this flag. By adding this flag you remove warnings like 
```
WARN[0000] Found orphan containers ([aws-mwaa-local-runner-2_6-local-runner-1]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
```
In my test of adding in the flag and running the start command after tweaking the name of service I didn't see any negative impacts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
