### PR TITLE
URGENT! fix broken build-image command due to incorrect mairadb path

### DIFF
--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -52,9 +52,9 @@ dnf install -y java-17-amazon-corretto
 sudo mkdir mariadb_rpm
 sudo chown airflow /mariadb_rpm
 
-wget https://mirror.mariadb.org/yum/11.1.2/fedora38-amd64/rpms/MariaDB-common-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-wget https://mirror.mariadb.org/yum/11.1.2/fedora38-amd64/rpms/MariaDB-shared-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-wget https://mirror.mariadb.org/yum/11.1.2/fedora38-amd64/rpms/MariaDB-devel-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+wget https://mirror.mariadb.org/yum/11.1.2/fedora38-$(uname -p)/rpms/MariaDB-common-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+wget https://mirror.mariadb.org/yum/11.1.2/fedora38-$(uname -p)/rpms/MariaDB-shared-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+wget https://mirror.mariadb.org/yum/11.1.2/fedora38-$(uname -p)/rpms/MariaDB-devel-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
 
 # install mariadb_devel and its dependencies
 sudo rpm -ivh /mariadb_rpm/*


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`./mwaa-local-env build-image` command from the README instructions is broken because of incorrect mariadb path in the `bootstrap.sh` script. This fix updates the path with the correct processor architecture name as per mariadb path index.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
