### PR TITLE
V2.7.2 - MariaDB failing to install

### DIFF
--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -52,9 +52,9 @@ dnf install -y java-17-amazon-corretto
 sudo mkdir mariadb_rpm
 sudo chown airflow /mariadb_rpm
 
-wget https://mirror.mariadb.org/yum/11.1.2/fedora38-amd64/rpms/MariaDB-common-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-wget https://mirror.mariadb.org/yum/11.1.2/fedora38-amd64/rpms/MariaDB-shared-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-wget https://mirror.mariadb.org/yum/11.1.2/fedora38-amd64/rpms/MariaDB-devel-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-common-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-shared-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-devel-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
 
 # install mariadb_devel and its dependencies
 sudo rpm -ivh /mariadb_rpm/*

--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -52,9 +52,15 @@ dnf install -y java-17-amazon-corretto
 sudo mkdir mariadb_rpm
 sudo chown airflow /mariadb_rpm
 
-wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-common-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-shared-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-devel-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+if [[ $(uname -p) == "aarch64" ]]; then
+  wget https://mirror.mariadb.org/yum/11.1/fedora38-aarch64/rpms/MariaDB-common-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.1/fedora38-aarch64/rpms/MariaDB-shared-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.1/fedora38-aarch64/rpms/MariaDB-devel-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+else
+  wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-common-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-shared-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-devel-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+fi
 
 # install mariadb_devel and its dependencies
 sudo rpm -ivh /mariadb_rpm/*


### PR DESCRIPTION
*Description of changes:*

MariaDB fails to be installed in v2.7.2 due to a bad path being provided. Additionally, there is a hardcoded instance of `amd64` in the path which should be parametrized instead by the user's current architecture.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

![image (5)](https://github.com/aws/aws-mwaa-local-runner/assets/139386268/8f03c8dc-ef8e-4a69-82dd-e7a30c0883d8)

*Description of testing:*

- Tested that it builds locally (macOS)
- Automated tests show it builds for x86_64
