### PR TITLE
Add AWS_DEFAULT_REGION to .env.localrunner

### DIFF
--- a/docker/config/.env.localrunner
+++ b/docker/config/.env.localrunner
@@ -3,6 +3,7 @@
 # AWS_ACCESS_KEY_ID=XXXXXXXXXX
 # AWS_SECRET_ACCESS_KEY=YYYYYYYYYYYY
 # AWS_SESSION_TOKEN=ZZZZZZZZZZ 
+# AWS_DEFAULT_REGION=aws-region (e.g. us-east-1)
 
 # to change default password you'll need to delete the db-data folder (when running locally)
 DEFAULT_PASSWORD="test"


### PR DESCRIPTION
Add AWS_DEFAULT_REGION to .env.localrunner.

This would prevent some region sensitive sensors from failing due to missing default region (for example EMRStepSensor).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
