### PR TITLE
Package-Requirements passes along public URL constraints in packaged_requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ For example usage see [Installing Python dependencies using PyPi.org Requirement
 - There is a directory at the root of this repository called plugins. 
 - In this directory, create a file for your new custom plugin.
 - Add any Python dependencies to `requirements/requirements.txt`.
+- Adds a local `constraints.txt` file to the `requirements/` directory, that you can add to your S3 bucket's dag folder. Ensuring you have the complete package: packaged_requirements.txt, plugins.zip, and constraints.txt, to build your private Environment
 
 **Note**: this step assumes you have a DAG that corresponds to the custom plugin. For example usage [MWAA Code Examples](https://docs.aws.amazon.com/mwaa/latest/userguide/sample-code.html).
 
@@ -157,6 +158,7 @@ For example usage see [Installing Python dependencies using PyPi.org Requirement
 - Learn how to upload the requirements.txt file to your Amazon S3 bucket in [Installing Python dependencies](https://docs.aws.amazon.com/mwaa/latest/userguide/working-dags-dependencies.html).
 - Learn how to upload the DAG code to the dags folder in your Amazon S3 bucket in [Adding or updating DAGs](https://docs.aws.amazon.com/mwaa/latest/userguide/configuring-dag-folder.html).
 - Learn more about how to upload the plugins.zip file to your Amazon S3 bucket in [Installing custom plugins](https://docs.aws.amazon.com/mwaa/latest/userguide/configuring-dag-import-plugins.html).
+- If using `package-requirements`, make sure you upload the `constraints.txt` file that is auto-generated for you in the `requirements/` directory to your S3 bucket's dag folder.
 
 ## FAQs
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ For example usage see [Installing Python dependencies using PyPi.org Requirement
 - There is a directory at the root of this repository called plugins. 
 - In this directory, create a file for your new custom plugin.
 - Add any Python dependencies to `requirements/requirements.txt`.
-- Adds a local `constraints.txt` file to the `requirements/` directory, that you can add to your S3 bucket's dag folder. Ensuring you have the complete package: packaged_requirements.txt, plugins.zip, and constraints.txt, to build your private Environment
+- Adds a local `constraints.txt` file to the `plugins/` directory, this is zipped together into the `plugins.zip` artefact.
+- Creates a new `packaged_requirements.txt` file with the correct configuration for `--find-links` and `--constraint`. This file should be the one you rename to `requirements.txt` and upload to S3 to be used by MWAA.
 
 **Note**: this step assumes you have a DAG that corresponds to the custom plugin. For example usage [MWAA Code Examples](https://docs.aws.amazon.com/mwaa/latest/userguide/sample-code.html).
 
@@ -158,7 +159,6 @@ For example usage see [Installing Python dependencies using PyPi.org Requirement
 - Learn how to upload the requirements.txt file to your Amazon S3 bucket in [Installing Python dependencies](https://docs.aws.amazon.com/mwaa/latest/userguide/working-dags-dependencies.html).
 - Learn how to upload the DAG code to the dags folder in your Amazon S3 bucket in [Adding or updating DAGs](https://docs.aws.amazon.com/mwaa/latest/userguide/configuring-dag-folder.html).
 - Learn more about how to upload the plugins.zip file to your Amazon S3 bucket in [Installing custom plugins](https://docs.aws.amazon.com/mwaa/latest/userguide/configuring-dag-import-plugins.html).
-- If using `package-requirements`, make sure you upload the `constraints.txt` file that is auto-generated for you in the `requirements/` directory to your S3 bucket's dag folder.
 
 ## FAQs
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,7 @@ ARG INDEX_URL=""
 ENV AIRFLOW_HOME=${AIRFLOW_USER_HOME}
 ENV PATH="$PATH:/usr/local/airflow/.local/bin:/root/.local/bin:/usr/local/airflow/.local/lib/python3.10/site-packages"
 ENV PYTHON_VERSION=3.11.6
+ENV AIRFLOW_VERSION=2.7.2
 
 COPY script/bootstrap.sh /bootstrap.sh
 COPY script/systemlibs.sh /systemlibs.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ ARG INDEX_URL=""
 ENV AIRFLOW_HOME=${AIRFLOW_USER_HOME}
 ENV PATH="$PATH:/usr/local/airflow/.local/bin:/root/.local/bin:/usr/local/airflow/.local/lib/python3.10/site-packages"
 ENV PYTHON_VERSION=3.11.6
-ENV AIRFLOW_VERSION=2.7.2
+ENV AIRFLOW_VERSION=${AIRFLOW_VERSION}
 
 COPY script/bootstrap.sh /bootstrap.sh
 COPY script/systemlibs.sh /systemlibs.sh

--- a/docker/script/entrypoint.sh
+++ b/docker/script/entrypoint.sh
@@ -41,10 +41,11 @@ package_requirements() {
     if [[ -e "$AIRFLOW_HOME/$REQUIREMENTS_FILE" ]]; then
         echo "Packaging requirements.txt into plugins"
         pip3 download -r "$AIRFLOW_HOME/$REQUIREMENTS_FILE" -d "$AIRFLOW_HOME/plugins"
-        cd "$AIRFLOW_HOME/plugins"
+	  cd "$AIRFLOW_HOME/plugins"
         zip "$AIRFLOW_HOME/requirements/plugins.zip" *
         printf '%s\n%s\n' "--no-index" "$(cat $AIRFLOW_HOME/$REQUIREMENTS_FILE)" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt"
-        printf '%s\n%s\n' "--find-links /usr/local/airflow/plugins" "$(cat $AIRFLOW_HOME/requirements/packaged_requirements.txt)" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt"
+        printf '%s\n%s\n%s\n%s\n' "--find-links /usr/local/airflow/plugins" "--constraint \"$AIRFLOW_HOME/dags/constraints.txt\"" "$(cat $AIRFLOW_HOME/requirements/packaged_requirements.txt | grep -v '^--constraint .https://*')" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt"
+	      wget "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION%.*}.txt" -O $AIRFLOW_HOME/requirements/constraints.txt
     fi
 }
 

--- a/docker/script/entrypoint.sh
+++ b/docker/script/entrypoint.sh
@@ -41,7 +41,7 @@ package_requirements() {
     if [[ -e "$AIRFLOW_HOME/$REQUIREMENTS_FILE" ]]; then
         echo "Packaging requirements.txt into plugins"
         pip3 download -r "$AIRFLOW_HOME/$REQUIREMENTS_FILE" -d "$AIRFLOW_HOME/plugins"
-	  cd "$AIRFLOW_HOME/plugins"
+	cd "$AIRFLOW_HOME/plugins"
         zip "$AIRFLOW_HOME/requirements/plugins.zip" *
         printf '%s\n%s\n' "--no-index" "$(cat $AIRFLOW_HOME/$REQUIREMENTS_FILE)" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt"
         printf '%s\n%s\n%s\n%s\n' "--find-links /usr/local/airflow/plugins" "--constraint \"$AIRFLOW_HOME/dags/constraints.txt\"" "$(cat $AIRFLOW_HOME/requirements/packaged_requirements.txt | grep -v '^--constraint .https://*')" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt"

--- a/docker/script/entrypoint.sh
+++ b/docker/script/entrypoint.sh
@@ -41,11 +41,11 @@ package_requirements() {
     if [[ -e "$AIRFLOW_HOME/$REQUIREMENTS_FILE" ]]; then
         echo "Packaging requirements.txt into plugins"
         pip3 download -r "$AIRFLOW_HOME/$REQUIREMENTS_FILE" -d "$AIRFLOW_HOME/plugins"
-	cd "$AIRFLOW_HOME/plugins"
+        wget "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION%.*}.txt" -O $AIRFLOW_HOME/plugins/constraints.txt
+        cd "$AIRFLOW_HOME/plugins"
         zip "$AIRFLOW_HOME/requirements/plugins.zip" *
         printf '%s\n%s\n' "--no-index" "$(cat $AIRFLOW_HOME/$REQUIREMENTS_FILE)" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt"
-        printf '%s\n%s\n%s\n%s\n' "--find-links /usr/local/airflow/plugins" "--constraint \"$AIRFLOW_HOME/dags/constraints.txt\"" "$(cat $AIRFLOW_HOME/requirements/packaged_requirements.txt | grep -v '^--constraint .https://*')" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt"
-	      wget "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION%.*}.txt" -O $AIRFLOW_HOME/requirements/constraints.txt
+        printf '%s\n%s\n%s\n%s\n' "--find-links /usr/local/airflow/plugins" "--constraint /usr/local/airflow/plugins/constraints.txt" "$(cat $AIRFLOW_HOME/requirements/packaged_requirements.txt | grep -v '^--constraint .https://*')" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt" 
     fi
 }
 

--- a/docker/script/entrypoint.sh
+++ b/docker/script/entrypoint.sh
@@ -41,11 +41,11 @@ package_requirements() {
     if [[ -e "$AIRFLOW_HOME/$REQUIREMENTS_FILE" ]]; then
         echo "Packaging requirements.txt into plugins"
         pip3 download -r "$AIRFLOW_HOME/$REQUIREMENTS_FILE" -d "$AIRFLOW_HOME/plugins"
-        wget "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION%.*}.txt" -O $AIRFLOW_HOME/plugins/constraints.txt
+        wget "https://raw.githubusercontent.com/aws/aws-mwaa-local-runner/v${AIRFLOW_VERSION}/docker/config/constraints.txt" -O $AIRFLOW_HOME/plugins/constraints.txt
         cd "$AIRFLOW_HOME/plugins"
         zip "$AIRFLOW_HOME/requirements/plugins.zip" *
         printf '%s\n%s\n' "--no-index" "$(cat $AIRFLOW_HOME/$REQUIREMENTS_FILE)" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt"
-        printf '%s\n%s\n%s\n%s\n' "--find-links /usr/local/airflow/plugins" "--constraint /usr/local/airflow/plugins/constraints.txt" "$(cat $AIRFLOW_HOME/requirements/packaged_requirements.txt | grep -v '^--constraint .https://*')" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt" 
+        printf '%s\n%s\n%s\n%s\n' "--find-links /usr/local/airflow/plugins" "--constraint /usr/local/airflow/plugins/constraints.txt" "$(cat $AIRFLOW_HOME/requirements/packaged_requirements.txt | grep -v '^--constraint')" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt" 
     fi
 }
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
---constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.7.2/constraints-3.11.txt"
+--constraint "https://raw.githubusercontent.com/aws/aws-mwaa-local-runner/v2.7.2/docker/config/constraints.txt"
 
 apache-airflow-providers-snowflake==5.0.1
 apache-airflow-providers-mysql==5.3.1


### PR DESCRIPTION
*Issue #, if available:*
Currently when using `package-requirements` if your using constraints in your requirements.txt, these are also added to package_requirements.txt. If you don't modify it afterwards, PIP will fail to install in private MWAA as it won't reach public URL in constraints line.

*Description of changes:*
Provided a means of "grep" removing the used constraints, and adding in a local `constraints.txt` file, that is created using `wget` after package-requirements has completed. Ensuring that everything is completed together, in the same directory. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
