### PR TITLE
Add SELinux sharing labels

### DIFF
--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -11,7 +11,7 @@ services:
                 max-size: 10m
                 max-file: "3"
         volumes:
-            - "${PWD}/db-data:/var/lib/postgresql/data"
+            - "${PWD}/db-data:/var/lib/postgresql/data:z"
 
     local-runner:
         image: amazon/mwaa-local:2_8
@@ -26,10 +26,10 @@ services:
                 max-size: 10m
                 max-file: "3"
         volumes:
-            - "${PWD}/dags:/usr/local/airflow/dags"
-            - "${PWD}/plugins:/usr/local/airflow/plugins"
-            - "${PWD}/requirements:/usr/local/airflow/requirements"
-            - "${PWD}/startup_script:/usr/local/airflow/startup"
+            - "${PWD}/dags:/usr/local/airflow/dags:z"
+            - "${PWD}/plugins:/usr/local/airflow/plugins:z"
+            - "${PWD}/requirements:/usr/local/airflow/requirements:z"
+            - "${PWD}/startup_script:/usr/local/airflow/startup:z"
         ports:
             - "8080:8080"
         command: local-runner

--- a/docker/docker-compose-resetdb.yml
+++ b/docker/docker-compose-resetdb.yml
@@ -11,7 +11,7 @@ services:
                 max-size: 10m
                 max-file: "3"
         volumes:
-            - "${PWD}/db-data:/var/lib/postgresql/data"
+            - "${PWD}/db-data:/var/lib/postgresql/data":z
 
     resetdb:
         image: amazon/mwaa-local:2_8
@@ -25,9 +25,9 @@ services:
                 max-size: 10m
                 max-file: "3"
         volumes:
-            - "${PWD}/dags:/usr/local/airflow/dags"
-            - "${PWD}/plugins:/usr/local/airflow/plugins"
-            - "${PWD}/requirements:/usr/local/airflow/requirements"
+            - "${PWD}/dags:/usr/local/airflow/dags":z
+            - "${PWD}/plugins:/usr/local/airflow/plugins":z
+            - "${PWD}/requirements:/usr/local/airflow/requirements":z
         ports:
             - "8080:8080"
         command: resetdb

--- a/docker/docker-compose-sequential.yml
+++ b/docker/docker-compose-sequential.yml
@@ -11,9 +11,9 @@ services:
                 max-size: 10m
                 max-file: "3"
         volumes:
-            - "${PWD}/dags:/usr/local/airflow/dags"
-            - "${PWD}/plugins:/usr/local/airflow/plugins"
-            - "${PWD}/requirements:/usr/local/airflow/requirements"
+            - "${PWD}/dags:/usr/local/airflow/dags:z"
+            - "${PWD}/plugins:/usr/local/airflow/plugins:z"
+            - "${PWD}/requirements:/usr/local/airflow/requirements:z"
         ports:
             - "8080:8080"
         command: webserver

--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -68,7 +68,7 @@ test-requirements)
      echo "Container amazon/mwaa-local:$AIRFLOW_VERSION not built. Building locally."
      build_image
    fi
-   docker run -v $(pwd)/dags:/usr/local/airflow/dags -v $(pwd)/plugins:/usr/local/airflow/plugins -v $(pwd)/requirements:/usr/local/airflow/requirements -it amazon/mwaa-local:$AIRFLOW_VERSION test-requirements
+   docker run -v $(pwd)/dags:/usr/local/airflow/dags:z -v $(pwd)/plugins:/usr/local/airflow/plugins:z -v $(pwd)/requirements:/usr/local/airflow/requirements:z -it amazon/mwaa-local:$AIRFLOW_VERSION test-requirements
    ;;
 test-startup-script)
    BUILT_IMAGE=$(docker images -q amazon/mwaa-local:$AIRFLOW_VERSION)
@@ -78,7 +78,7 @@ test-startup-script)
       echo "Container amazon/mwaa-local:$AIRFLOW_VERSION not built. Building locally."
       build_image
    fi
-   docker run -v $(pwd)/startup_script:/usr/local/airflow/startup -it amazon/mwaa-local:$AIRFLOW_VERSION test-startup-script
+   docker run -v $(pwd)/startup_script:/usr/local/airflow/startup:z -it amazon/mwaa-local:$AIRFLOW_VERSION test-startup-script
    ;;
 package-requirements)
    BUILT_IMAGE=$(docker images -q amazon/mwaa-local:$AIRFLOW_VERSION)
@@ -88,7 +88,7 @@ package-requirements)
      echo "Container amazon/mwaa-local:$AIRFLOW_VERSION not built. Building locally."
      build_image
    fi
-   docker run -v $(pwd)/dags:/usr/local/airflow/dags -v $(pwd)/plugins:/usr/local/airflow/plugins -v $(pwd)/requirements:/usr/local/airflow/requirements -it amazon/mwaa-local:$AIRFLOW_VERSION package-requirements
+   docker run -v $(pwd)/dags:/usr/local/airflow/dags:z -v $(pwd)/plugins:/usr/local/airflow/plugins:z -v $(pwd)/requirements:/usr/local/airflow/requirements:z -it amazon/mwaa-local:$AIRFLOW_VERSION package-requirements
    ;;   
 build-image)
    build_image


### PR DESCRIPTION
This fixes running the environment on a Linux system with enabled SELinux (such as Fedora 39). Note that I opted for a more open :z instead of private sharing using :Z, mainly because I am not yet familiar with the exact setup and which parts run together with which other parts.

See also https://prefetch.net/blog/2017/09/30/using-docker-volumes-on-selinux-enabled-servers/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
