### PR TITLE
fix: cryptography for fernet key gen

### DIFF
--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -34,14 +34,13 @@ tar -xf ./python_install/$python_tar -C ./python_install
 dnf install -y dnf-plugins-core
 dnf builddep -y python3
 
-
 pushd /python_install/$python_file 
 ./configure 
 make install -j $(nproc) # use -j to set the cores for the build
 popd
 
 # Upgrade pip
-pip3 install $PIP_OPTION --upgrade 'pip<23'
+pip3 install $PIP_OPTION --upgrade 'pip<23' cryptography
 
 # openjdk is required for JDBC to work with Airflow
 dnf install -y java-17-amazon-corretto

--- a/docker/script/systemlibs.sh
+++ b/docker/script/systemlibs.sh
@@ -27,9 +27,6 @@ dnf install -y jq
 # nc is used to check DB connectivity
 dnf install -y nc
 
-# Needed for generating fernet key for local runner
-dnf install -y python3-cryptography
-
 # Install additional system library dependencies. Provided as a string of libraries separated by space
 if [ -n "${SYSTEM_DEPS}" ]; then dnf install -y "${SYSTEM_DEPS}"; fi
 


### PR DESCRIPTION
*Issue #, if available:* #350

*Description of changes:* package 'cryptography' was installed for system python (which is 3.9) via apt. Since during build we replace system python with 3.11(.7) and later use it as primary one, it is required to install package `cryptography` via pip with `root` permissions to be available system-wide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
