### PR TITLE
Changes to make packaging MWAA plugin.zip easier for MoveRDC

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zip filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ dags/**/*.pyc
 /logs
 /db-data
 .DS_Store
+
+# MoveRDC-specific
+plugins/*.whl
+plugins/*.tar.gz

--- a/requirements/packaged_requirements.txt
+++ b/requirements/packaged_requirements.txt
@@ -1,0 +1,16 @@
+--find-links /usr/local/airflow/plugins
+--no-index
+
+apache_airflow==2.7.2
+apache-airflow-providers-amazon==8.7.1
+apache-airflow-providers-slack==8.1.0
+apache-airflow-providers-ssh==3.7.3
+python_aws_env==0.0.13
+acryl-datahub-airflow-plugin==0.13.1.3
+
+wheel==0.43.0
+
+google-api-python-client==2.102.0
+google-auth==2.23.2
+pandas==2.1.1
+# To refresh plugins.zip, please see ./user-guide/adding_plugins_libraries.md

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,17 @@
 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.7.2/constraints-3.11.txt"
+--extra-index-url https://artifactory.moveaws.com/artifactory/api/pypi/InnerOpenSource-shared-pypi-local/simple
 
-apache-airflow-providers-snowflake==5.0.1
-apache-airflow-providers-mysql==5.3.1
+apache_airflow==2.7.2
+apache-airflow-providers-amazon==8.7.1
+apache-airflow-providers-slack==8.1.0
+apache-airflow-providers-ssh==3.7.3
+python_aws_env==0.0.13
+acryl-datahub-airflow-plugin==0.13.1.3
+
+pynacl @ https://files.pythonhosted.org/packages/66/28/ca86676b69bf9f90e710571b67450508484388bfce09acf8a46f0b8c785f/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+wheel==0.43.0
+
+google-api-python-client==2.102.0
+google-auth==2.23.2
+pandas==2.1.1
+# To refresh plugins.zip, please see ./user-guide/adding_plugins_libraries.md


### PR DESCRIPTION
Adds some steps to the bundling package; allows for LFS storage for large `plugins.zip` files.