### PR TITLE
Pass through AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Runs a local Apache Airflow environment that is a close representation of MWAA b
 
 To stop the local environment, Ctrl+C on the terminal and wait till the local runner and the postgres containers are stopped.
 
+If you need to authenticate with any live AWS services such as S3, export the following environment variables, which will get passed through:
+
+```bash
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_DEFAULT_REGION=...
+./mwaa-local-env start
+```
+
 ### Step three: Accessing the Airflow UI
 
 By default, the `bootstrap.sh` script creates a username and password for your local Airflow environment.

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -21,6 +21,9 @@ services:
         environment:
             - LOAD_EX=n
             - EXECUTOR=Local
+            - "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
+            - "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
+            - "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}"
         logging:
             options:
                 max-size: 10m


### PR DESCRIPTION
## Problem statement

Previously, you would have to bake AWS credentials into the container to be able to authenticate with AWS services such as S3. This is insecure and involves changing the container build process.

## Proposed solution

Pass through the following environment variables, which are commonly used for authenticating with AWS APIs via AWS libraries such as boto3 or the AWS CLI: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`.

1. Pass through the variables in docker-compose-local.yaml
2. Update README.md to document this change

## Misc

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
