### PR TITLE
Fix/unable to build docker image on windows errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ cd aws-mwaa-local-runner
 ```
 
 ### Step one: Building the Docker image
+#### For Windows Users Only
+
+If you are using Windows, you may need to run the following commands to adjust line endings in the script files before starting the script. Windows often modifies line endings in .sh files, which can cause issues. The commands below will convert the line endings to Unix format:
+
+```bash
+sed -i -e 's/\r$//' docker/script/bootstrap.sh
+sed -i -e 's/\r$//' docker/script/systemlibs.sh
+sed -i -e 's/\r$//' docker/script/generate_key.sh
+```
+
 
 Build the Docker container image using the following command:
 
@@ -73,6 +83,7 @@ Build the Docker container image using the following command:
 ### Step two: Running Apache Airflow
 
 #### Local runner
+
 
 Runs a local Apache Airflow environment that is a close representation of MWAA by configuration.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ cd aws-mwaa-local-runner
 ### Step one: Building the Docker image
 #### For Windows Users Only
 
-If you are using Windows, you may need to run the following commands to adjust line endings in the script files before starting the script. Windows often modifies line endings in .sh files, which can cause issues. The commands below will convert the line endings to Unix format:
+If you are using Windows, you may need to run the following commands to adjust line endings in the script files before building the docker image. Windows often modifies line endings in .sh files, which can cause issues. The commands below will convert the line endings to Unix format:
 
 ```bash
 sed -i -e 's/\r$//' docker/script/bootstrap.sh


### PR DESCRIPTION
*Issue #, if available:*
#275 #279 
*Description of changes:*

If we are using Windows, we may need to run the following commands to adjust line endings in the script files before building the docker image. Windows often modifies line endings in .sh files, which can cause issues. I faced this issue every time I tried to run MWAA on my local machine with docker and wsl2 installed. The commands below will convert the line endings to Unix format:

```bash
sed -i -e 's/\r$//' docker/script/bootstrap.sh
sed -i -e 's/\r$//' docker/script/systemlibs.sh
sed -i -e 's/\r$//' docker/script/generate_key.sh
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
