### PR TITLE
Corrected help text example syntax

### DIFF
--- a/mwaa-local-env
+++ b/mwaa-local-env
@@ -8,7 +8,7 @@ display_help() {
    echo "======================================"
    echo "   MWAA Local Runner CLI"
    echo "======================================"
-   echo "Syntax: mwaa-local-runner [command]"
+   echo "Syntax: mwaa-local-env [command]"
    echo "Airflow version $AIRFLOW_VERSION"
    echo "---commands---"
    echo "help                   Print CLI help"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The example syntax in the `mwaa-local-env` incorrectly references `mwaa-local-runner`.

![I'm Helping](https://media1.tenor.com/m/5WMD9NxHnCUAAAAC/ralph-wiggum-simpsons.gif)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
