### PR TITLE
FIX:  `package-requirements` always returns exit code 0, even on failure

### DIFF
--- a/docker/script/entrypoint.sh
+++ b/docker/script/entrypoint.sh
@@ -41,6 +41,10 @@ package_requirements() {
     if [[ -e "$AIRFLOW_HOME/$REQUIREMENTS_FILE" ]]; then
         echo "Packaging requirements.txt into plugins"
         pip3 download -r "$AIRFLOW_HOME/$REQUIREMENTS_FILE" -d "$AIRFLOW_HOME/plugins"
+        pip_exit_code=$?
+        if [[ $pip_exit_code -ne 0 ]]; then
+          exit $pip_exit_code
+        fi
         cd "$AIRFLOW_HOME/plugins"
         zip "$AIRFLOW_HOME/requirements/plugins.zip" *
         printf '%s\n%s\n' "--no-index" "$(cat $AIRFLOW_HOME/$REQUIREMENTS_FILE)" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt"


### PR DESCRIPTION
*Issue #:*
Closes #388 

*Description of changes:*
Check the exit code for `pip3 download -r ...` in `entrypoint.sh`. If non-zero, exit with the same error code. 

Note: This only solves one particular case. A more thorough solution would be to use something like `set -e` for all these "utility" commands (`package-requirements`,`test-startup-script`, etc). But I imagine that is a larger (and possibly internal) discussion.

If this change is accepted, I also request that it get merged to all lower environments (or at least all supported ones) as well. This bug exists in v2.2.2-v2.9.2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
