### PR TITLE
Convert script files to Unix format (LF) for cross-platform compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
*Issue #, if available:*
Script files are not recognized correctly during Windows installation due to incorrect line endings (CRLF).

*Description of changes:*
Converted script files from CRLF (Windows line endings) to LF (Unix line endings) to ensure compatibility across different operating systems. This change is essential for ensuring the script files are properly recognized during the Windows installation process and to maintain consistency in Unix-based environments.

By submitting this pull request, I confirm that this contribution can be used, modified, copied, and redistributed under the terms of your choice.