### PR TITLE
Recursive inclusion of content for plugins foldeer

### DIFF
--- a/docker/script/entrypoint.sh
+++ b/docker/script/entrypoint.sh
@@ -42,7 +42,7 @@ package_requirements() {
         echo "Packaging requirements.txt into plugins"
         pip3 download -r "$AIRFLOW_HOME/$REQUIREMENTS_FILE" -d "$AIRFLOW_HOME/plugins"
         cd "$AIRFLOW_HOME/plugins"
-        zip "$AIRFLOW_HOME/requirements/plugins.zip" *
+        zip -r "$AIRFLOW_HOME/requirements/plugins.zip" *
         printf '%s\n%s\n' "--no-index" "$(cat $AIRFLOW_HOME/$REQUIREMENTS_FILE)" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt"
         printf '%s\n%s\n' "--find-links /usr/local/airflow/plugins" "$(cat $AIRFLOW_HOME/requirements/packaged_requirements.txt)" > "$AIRFLOW_HOME/requirements/packaged_requirements.txt"
     fi


### PR DESCRIPTION
We are using special Operators that we packaged in the plugins folder. When we want to package the requirements and our existing code, we need to zip it with the option "-r" for recursive inclusion. 

*Issue #, if available:*

*Description of changes:*
adding option "-r" to zip command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
