### PR TITLE
Update MariaDB version to 11.4.3 in bootstrap script because 11.1 was…

### DIFF
--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -53,13 +53,13 @@ sudo mkdir mariadb_rpm
 sudo chown airflow /mariadb_rpm
 
 if [[ $(uname -p) == "aarch64" ]]; then
-  wget https://mirror.mariadb.org/yum/11.1/fedora38-aarch64/rpms/MariaDB-common-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-  wget https://mirror.mariadb.org/yum/11.1/fedora38-aarch64/rpms/MariaDB-shared-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-  wget https://mirror.mariadb.org/yum/11.1/fedora38-aarch64/rpms/MariaDB-devel-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.4/fedora38-aarch64/rpms/MariaDB-common-11.4.3-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.4/fedora38-aarch64/rpms/MariaDB-shared-11.4.3-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.4/fedora38-aarch64/rpms/MariaDB-devel-11.4.3-1.fc38.$(uname -p).rpm -P /mariadb_rpm
 else
-  wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-common-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-  wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-shared-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-  wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-devel-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.4/fedora38-amd64/rpms/MariaDB-common-11.4.3-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.4/fedora38-amd64/rpms/MariaDB-shared-11.4.3-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.4/fedora38-amd64/rpms/MariaDB-devel-11.4.3-1.fc38.$(uname -p).rpm -P /mariadb_rpm
 fi
 
 # install mariadb_devel and its dependencies


### PR DESCRIPTION
*Issue:* https://github.com/aws/aws-mwaa-local-runner/issues/409

*Description of changes:* Update MariaDB version to 11.4.3 in bootstrap script because 11.1 was Not Found on mirror repo in MWAA v2.9.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
