### PR TITLE
BUGFIX Enforcing AIRFLOW_HOME workdir before executing startup script

### DIFF
--- a/docker/script/entrypoint.sh
+++ b/docker/script/entrypoint.sh
@@ -126,6 +126,7 @@ case "$1" in
     fi
 
 
+    cd "$AIRFLOW_HOME"
     execute_startup_script
     source stored_env
     export AIRFLOW_HOME="/usr/local/airflow"


### PR DESCRIPTION
*Issue #, if available:*
fixes #428 

*Description of changes:*
See #428  for details. This is one of the possible changes that should ensure that `stored_env` will be located in the $AIRFLOW_HOME. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
