### PR TITLE
Fix constraints txt permission denied issue

### DIFF
--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -66,6 +66,8 @@ fi
 # install mariadb_devel and its dependencies
 sudo rpm -ivh /mariadb_rpm/*
 
+sudo chown airflow /*.txt
+
 # install minimal Airflow packages
 sudo -u airflow pip3 install $PIP_OPTION --no-use-pep517 --constraint /constraints.txt poetry
 sudo -u airflow pip3 install $PIP_OPTION --constraint /constraints.txt cached-property


### PR DESCRIPTION
*Issue #, if available:*

Following issue occurs when running `./mwaa-local-env build-image` command with `2.4.3` version.

```bash
#15 77.62 + sudo -u airflow pip3 install --no-use-pep517 --constraint
/constraints.txt poetry
#15 77.87 Defaulting to user installation because normal site-packages is not
writeable
#15 77.89 ERROR: Could not open requirements file: [Errno 13] Permission
denied: '/constraints.txt'
#15 78.03 
#15 78.03 [notice] A new release of pip available: 22.3.1 -> 25.0.1
#15 78.03 [notice] To update, run: pip3 install --upgrade pip
#15 ERROR: process "/bin/sh -c chmod u+x /bootstrap.sh && /bootstrap.sh" did
not complete successfully: exit code: 1
------
 > [11/21] RUN chmod u+x /bootstrap.sh && /bootstrap.sh:
302 Found
75.79 Location:
https://storage.googleapis.com/downloads-cdn.mariadb.com/mariadb_server/10.8/10.8.6/yum/rhel7-amd64/rpms/MariaDB-devel-10.8.6-1.el7.centos.x86_64.rpm?GoogleAccessId=downloads-sync%40downloads-234321.iam.gserviceaccount.com&Expires=1742541134&Signature=LG5hDY8Yug9YJa2ThbsB45SSSj5S32ixrRxPZt2%2FJ2BKLiNA8zBLmlNXbSbFX6PjJXIjaAzw4BFG8hy0l1CSZCJ5P%2BoIhz6pfC0O3EcIjjrSMf9ssZdPg06b3hpAJMyMPwf1eObd7fH6SC97d4mlvX%2FAapNw%2B5LsqUaOT5ZmT8dpVw86ok7tCSIX05bVQIcTEgYDUAAu1kC42oPuaFmxxbaWxJ9sYJMshVaNXuNJcDSqolZk27RS867%2BSM9gAeNj%2BjEK4OvZuyspDYtWWrEJW3V9Xqh0gGAUFmATWGj1aSTh9YpVZMfJW5wvgtpxp8NWDDVXXY5BNbvbhSwgFi8XWQ%3D%3D
[following]
200 OK
######
77.62 + sudo -u airflow pip3 install --no-use-pep517 --constraint
/constraints.txt poetry
77.87 Defaulting to user installation because normal site-packages is not
writeable
77.89 ERROR: Could not open requirements file: [Errno 13] Permission denied:
'/constraints.txt'
78.03 
Notice: 78.03 [notice] A new release of pip available: 22.3.1 -> 25.0.1
Notice: 78.03 [notice] To update, run: pip3 install --upgrade pip
------
Dockerfile:35
--------------------
  33 |     
  34 |     RUN chmod u+x /systemlibs.sh && /systemlibs.sh
  35 | >>> RUN chmod u+x /bootstrap.sh && /bootstrap.sh
  36 |     RUN chmod u+x /generate_key.sh && /generate_key.sh
  37 |     RUN chmod u+x /run-startup.sh
--------------------
ERROR: failed to solve: process "/bin/sh -c chmod u+x /bootstrap.sh &&
/bootstrap.sh" did not complete successfully: exit code: 1
```

*Description of changes:*

The root cause of this issue is the ownership of the /*.txt files (constraints.txt, mwaa-local-requirements.txt etc). The pip install which fails is running as airflow user but the /*.txt files is owned by root user
