### PR TITLE
fix: airflow db init has been deprecated

### DIFF
--- a/docker/script/entrypoint.sh
+++ b/docker/script/entrypoint.sh
@@ -132,7 +132,7 @@ case "$1" in
     export AIRFLOW__CORE__LOAD_EXAMPLES="False"
 
     install_requirements
-    airflow db init
+    airflow db migrate
     if [ "$AIRFLOW__CORE__EXECUTOR" = "LocalExecutor" ] || [ "$AIRFLOW__CORE__EXECUTOR" = "SequentialExecutor" ]; then
       # With the "Local" and "Sequential" executors it should all run in one container.
       airflow scheduler &
@@ -145,7 +145,7 @@ case "$1" in
   resetdb)
     airflow db reset -y
     sleep 2
-    airflow db init
+    airflow db migrate
     ;;
   test-requirements)
     # if S3_REQUIREMENTS_PATH


### PR DESCRIPTION
The `airflow db init` command has been deprecated, when I run it, Airflow says the following ``db init` is deprecated.  Use `db migrate` instead to migrate the db and/or airflow connections create-default-connections to create the default connections`.

This commit changes it to `airflow db migrate` as suggested.

This resolves issues with the db not being properly set up in my use case.

Full log:


```
 docker exec -it local-runner airflow db init
/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/configuration.py:859 FutureWarning: section/key [core/sql_alchemy_conn] has been deprecated, you should use[database/sql_alchemy_conn] instead. Please update your `conf.get*` call to use the new name
/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/metrics/statsd_logger.py:184 RemovedInAirflow3Warning: The basic metric validator will be deprecated in the future in favor of pattern-matching.  You can try this now by setting config option metrics_use_pattern_match to True.
/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/utils/providers_configuration_loader.py:55 DeprecationWarning: `db init` is deprecated.  Use `db migrate` instead to migrate the db and/or airflow connections create-default-connections to create the default connections
DB: sqlite:////usr/local/airflow/airflow.db
[2025-03-27T13:05:37.071+0000] {{migration.py:207}} INFO - Context impl SQLiteImpl.
[2025-03-27T13:05:37.072+0000] {{migration.py:210}} INFO - Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running stamp_revision  -> 5f2621c13b39
Traceback (most recent call last):
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/cryptography/fernet.py", line 34, in __init__
    key = base64.urlsafe_b64decode(key)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/base64.py", line 134, in urlsafe_b64decode
    return b64decode(s)
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/base64.py", line 88, in b64decode
    return binascii.a2b_base64(s, strict_mode=validate)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
binascii.Error: Incorrect padding

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/models/crypto.py", line 86, in get_fernet
    [Fernet(fernet_part.encode("utf-8")) for fernet_part in fernet_key.split(",")]
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/models/crypto.py", line 86, in <listcomp>
    [Fernet(fernet_part.encode("utf-8")) for fernet_part in fernet_key.split(",")]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/cryptography/fernet.py", line 36, in __init__
    raise ValueError(
ValueError: Fernet key must be 32 url-safe base64-encoded bytes.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/airflow/.local/bin/airflow", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/__main__.py", line 62, in main
    args.func(args)
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/cli/cli_config.py", line 49, in command
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/utils/providers_configuration_loader.py", line 55, in wrapped_function
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/cli/commands/db_command.py", line 56, in initdb
    db.initdb()
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/utils/session.py", line 97, in wrapper
    return func(*args, session=session, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/utils/db.py", line 802, in initdb
    create_default_connections(session=session)
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/utils/session.py", line 94, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/utils/db.py", line 185, in create_default_connections
    Connection(
  File "<string>", line 4, in __init__
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/sqlalchemy/orm/state.py", line 481, in _initialize_instance
    with util.safe_reraise():
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
    compat.raise_(
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/sqlalchemy/orm/state.py", line 479, in _initialize_instance
    return manager.original_init(*mixed[1:], **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/models/connection.py", line 177, in __init__
    self.extra = extra
    ^^^^^^^^^^
  File "<string>", line 1, in __set__
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/models/connection.py", line 379, in set_extra
    fernet = get_fernet()
             ^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/models/crypto.py", line 90, in get_fernet
    raise AirflowException(f"Could not create Fernet object: {value_error}")
airflow.exceptions.AirflowException: Could not create Fernet object: Fernet key must be 32 url-safe base64-encoded bytes.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.