### PR TITLE
feat: Add AWS credentials auto-refresh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,29 @@ git clone https://github.com/aws/aws-mwaa-local-runner.git
 cd aws-mwaa-local-runner
 ```
 
+### AWS Credentials Configuration (Optional)
+
+For DAGs that interact with AWS services, you can configure credentials in two ways:
+
+#### Option 1: Auto-refresh with AWS Profile (Recommended for local development)
+
+Set `AWS_PROFILE=your-profile-name` in `docker/config/.env.localrunner`. The container will automatically pick up fresh credentials when you refresh them via `aws sso login`, Leapp, or aws-vault. No container restart needed.
+
+**How it works:**
+- Your `~/.aws` directory is mounted read-only into the container
+- When you refresh credentials on your host, the container immediately sees the changes
+- Saves time - no need to stop/restart container when credentials expire
+
+**Security Note:** ⚠️
+- All AWS profiles in your `~/.aws` directory are accessible to the container (not just the selected profile)
+- The mount is read-only - the container cannot modify your credentials
+- **Only run trusted DAG code** in your local environment
+- **Recommended for local development only** - production MWAA uses IAM roles
+
+#### Option 2: Manual Credentials (Legacy)
+
+Set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` in `docker/config/.env.localrunner`. Requires container restart when credentials expire.
+
 ### Step one: Building the Docker image
 
 Build the Docker container image using the following command:

--- a/docker/config/.env.localrunner
+++ b/docker/config/.env.localrunner
@@ -1,8 +1,32 @@
 # Any environment variables set in this .env.localrunner file will be set in local-runner on start
-# Example environment variables using temporary security credentials
-# AWS_ACCESS_KEY_ID=XXXXXXXXXX
-# AWS_SECRET_ACCESS_KEY=YYYYYYYYYYYY
-# AWS_SESSION_TOKEN=ZZZZZZZZZZ 
+
+# AWS Credentials Configuration
+# ==============================
+# 
+# Option 1 (Recommended for local development): Use AWS Profile with auto-refresh
+#   Set your AWS profile name below. The container mounts your ~/.aws directory (read-only)
+#   and automatically picks up fresh credentials when you refresh them on your host via:
+#   - aws sso login --profile your-profile-name
+#   - Leapp session refresh
+#   - aws-vault exec your-profile-name
+#   
+#   Benefits: No container restart needed when credentials expire
+#   
+#   Example:
+#   AWS_PROFILE=your-profile-name
+#
+#   ⚠️ SECURITY NOTE:
+#   - All AWS profiles in your ~/.aws directory are accessible to the container
+#   - The mount is read-only - container cannot modify your credentials
+#   - Only run trusted DAG code in your local environment
+#   - For production MWAA, use IAM roles (not credentials)
+#
+# Option 2 (Legacy): Use temporary security credentials
+#   Uncomment and set these variables. Requires container restart when credentials expire.
+#   
+#   AWS_ACCESS_KEY_ID=XXXXXXXXXX
+#   AWS_SECRET_ACCESS_KEY=YYYYYYYYYYYY
+#   AWS_SESSION_TOKEN=ZZZZZZZZZZ
 
 # to change default password you'll need to delete the db-data folder (when running locally)
 DEFAULT_PASSWORD="test"

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -21,6 +21,7 @@ services:
     environment:
       - LOAD_EX=n
       - EXECUTOR=Local
+      - AWS_SDK_LOAD_CONFIG=1
     logging:
       options:
         max-size: 10m
@@ -30,6 +31,7 @@ services:
       - "${PWD}/plugins:/usr/local/airflow/plugins"
       - "${PWD}/requirements:/usr/local/airflow/requirements"
       - "${PWD}/startup_script:/usr/local/airflow/startup"
+      - "${HOME}/.aws:/usr/local/airflow/.aws:ro"
     ports:
       - "8080:8080"
     command: local-runner


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Enable automatic AWS credential refresh without container restart by mounting host ~/.aws directory. This improves developer experience when using AWS SSO, Leapp, or other credential managers with temporary credentials.

Changes:
- Mount ~/.aws directory read-only in docker-compose-local.yml
- Set AWS_SDK_LOAD_CONFIG=1 to enable profile-based authentication
- Update .env.localrunner with documentation for both approaches
- Add comprehensive documentation in docs/AWS_CREDENTIALS_AUTO_REFRESH.md
- Update README.md with credential configuration guidance

Benefits:
- No container restart needed when credentials expire
- Works with AWS SSO, Leapp, aws-vault, and similar tools
- Maintains backward compatibility with manual credential setting
- Improves local development workflow

Security considerations documented in detail in the new documentation file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
