### PR TITLE
Pin actions SHAs to latest same major

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v2.6.0
     - name: Build
       run: ./mwaa-local-env build-image


### PR DESCRIPTION
This is being tracked [here](https://github.com/ministryofjustice/analytical-platform-security/issues/26)
Pinning any actions to specific SHA to mitigate security risk.
Use latest same major version to avoid compatibility issues. 
