### PR TITLE
Set permissions for constraints and requirements files

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,7 @@ COPY script/verification.sh /verification.sh
 COPY config/constraints.txt /constraints.txt
 COPY config/mwaa-base-providers-requirements.txt /mwaa-base-providers-requirements.txt
 
+RUN chmod 644 /constraints.txt /mwaa-base-providers-requirements.txt
 RUN chmod u+x /systemlibs.sh && /systemlibs.sh
 RUN chmod u+x /bootstrap.sh && /bootstrap.sh
 RUN chmod u+x /generate_key.sh && /generate_key.sh


### PR DESCRIPTION
This became necessary on a corporate machine I was trying to run the image build on.

*No Issue*

*Description of changes:*
Adds a RUN statement to the dockerfile setting permission on the constraints and requirements files to explicitly allow them to be readable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
